### PR TITLE
SCD1 Snapshot Merge implementation and SCD2Merge Enhancements

### DIFF
--- a/core/src/main/java/com/arcesium/swiftlake/SwiftLakeEngine.java
+++ b/core/src/main/java/com/arcesium/swiftlake/SwiftLakeEngine.java
@@ -878,6 +878,38 @@ public class SwiftLakeEngine implements AutoCloseable {
   }
 
   /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) to the specified table.
+   *
+   * @param tableName The name of the table to apply the snapshot to.
+   * @return A SnapshotModeSetTableFilter object for further configuration.
+   */
+  public SCD1Merge.SnapshotModeSetTableFilter applySnapshotAsSCD1(String tableName) {
+    return SCD1Merge.applySnapshot(this, tableName);
+  }
+
+  /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) to the specified table.
+   *
+   * @param table The Table object to apply the snapshot to.
+   * @return A SnapshotModeSetTableFilter object for further configuration.
+   */
+  public SCD1Merge.SnapshotModeSetTableFilter applySnapshotAsSCD1(Table table) {
+    return SCD1Merge.applySnapshot(this, table);
+  }
+
+  /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) to the specified table batch
+   * transaction.
+   *
+   * @param tableBatchTransaction The TableBatchTransaction object to apply the snapshot to.
+   * @return A SnapshotModeSetTableFilter object for further configuration.
+   */
+  public SCD1Merge.SnapshotModeSetTableFilter applySnapshotAsSCD1(
+      TableBatchTransaction tableBatchTransaction) {
+    return SCD1Merge.applySnapshot(this, tableBatchTransaction);
+  }
+
+  /**
    * Initiates an SCD2 (Slowly Changing Dimension Type 2) merge operation on the specified table.
    *
    * @param tableName The name of the table to apply SCD2 changes to.

--- a/core/src/main/java/com/arcesium/swiftlake/commands/SCD1Merge.java
+++ b/core/src/main/java/com/arcesium/swiftlake/commands/SCD1Merge.java
@@ -23,6 +23,7 @@ import com.arcesium.swiftlake.dao.CommonDao;
 import com.arcesium.swiftlake.dao.SCD1MergeDao;
 import com.arcesium.swiftlake.expressions.Expression;
 import com.arcesium.swiftlake.expressions.Expressions;
+import com.arcesium.swiftlake.io.SwiftLakeFileIO;
 import com.arcesium.swiftlake.metrics.CommitMetrics;
 import com.arcesium.swiftlake.mybatis.SwiftLakeSqlSessionFactory;
 import com.arcesium.swiftlake.sql.SqlQueryProcessor;
@@ -36,17 +37,21 @@ import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.IsolationLevel;
-import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,9 +136,25 @@ public class SCD1Merge {
     // Validate columns and set up properties
     WriteUtil.validateColumns(table, properties.getColumns());
     properties.setAllColumns(WriteUtil.getColumns(table));
-    WriteUtil.validateColumns(properties.getAllColumns(), properties.getKeyColumns(), null, null);
+    if (properties.getMode() == SCD1MergeMode.SNAPSHOT) {
+      if (properties.getValueColumns() == null) {
+        properties.setValueColumns(
+            WriteUtil.getRemainingColumns(properties.getAllColumns(), properties.getKeyColumns()));
+      }
+      ValidationException.check(
+          !properties.getValueColumns().isEmpty(), "Value columns cannot be empty.");
+      validateColumns(
+          properties.getAllColumns(),
+          properties.getKeyColumns(),
+          properties.getValueColumns(),
+          properties.getValueColumnMetadataMap());
+    } else {
+      validateColumns(properties.getAllColumns(), properties.getKeyColumns(), null, null);
+      validateChangesMode();
+    }
     WriteUtil.validateTableFilterColumns(
         properties.getTableFilterColumns(), properties.getKeyColumns());
+    processValueColumnMetadata(table.schema());
 
     // Create temporary directory for merge operation
     String tmpDir = swiftLakeEngine.getLocalDir() + "/scd1_merge/" + UUID.randomUUID().toString();
@@ -144,7 +165,8 @@ public class SCD1Merge {
     try {
       // Set up extra columns if operation type column is specified
       List<String> extraColumnsInInput = null;
-      if (properties.getOperationTypeColumn() != null) {
+      if (properties.getMode() == SCD1MergeMode.CHANGES
+          && properties.getOperationTypeColumn() != null) {
         extraColumnsInInput = Arrays.asList(properties.getOperationTypeColumn());
       }
 
@@ -193,12 +215,15 @@ public class SCD1Merge {
                 + ")";
       }
 
-      // Check if source is empty
-      if (commonDao.isTableEmpty(sourceTableName)) {
-        return null;
+      sourceTableName = this.createTableFilter(sourceTableName);
+
+      if (properties.getMode() == SCD1MergeMode.CHANGES || properties.isSkipEmptySource()) {
+        // Check if source is empty
+        if (commonDao.isTableEmpty(sourceTableName)) {
+          return null;
+        }
       }
 
-      sourceTableName = this.createTableFilter(sourceTableName);
       Expression tableFilter = properties.getTableFilter();
       // Scan target table
       swiftLakeTableScanResult =
@@ -207,45 +232,82 @@ public class SCD1Merge {
               .executeTableScan(table, tableFilter, true, true, null, branch, null, false);
       List<DataFile> matchedDataFiles = swiftLakeTableScanResult.getScanResult().getRight();
       boolean isAppendOnly = matchedDataFiles.isEmpty();
-      String destinationTableName = swiftLakeTableScanResult.getSql();
+      properties.setAppendOnly(isAppendOnly);
+      properties.setSourceTableName(sourceTableName);
 
-      PartitionSpec partitionSpec = table.spec();
-      boolean isPartitionedTable = partitionSpec.isPartitioned();
+      String destinationTableName = swiftLakeTableScanResult.getSql();
+      String boundaryCondition =
+          swiftLakeEngine.getSchemaEvolution().getDuckDBFilterSql(table, tableFilter);
+      properties.setBoundaryCondition(boundaryCondition);
 
       List<String> modifiedFiles = null;
-      properties.setSourceTableName(sourceTableName);
-      properties.setAppendOnly(isAppendOnly);
+      String mergeResultsSql = null;
+      String diffsFileBaseFolder = "/diffs_" + UUID.randomUUID();
+      String diffsFilePath = tmpDir + diffsFileBaseFolder;
+      String modifiedFileNamesFilePath =
+          tmpDir + "/modified_files_" + UUID.randomUUID() + ".parquet";
+      SwiftLakeFileIO fileIO = (SwiftLakeFileIO) table.io();
 
-      // Handle non-append-only scenario
-      if (!isAppendOnly) {
-        String diffsFilePath = tmpDir + "/diffs_" + UUID.randomUUID().toString();
-        String modifiedFileNamesFilePath =
-            tmpDir + "/modified_files_" + UUID.randomUUID().toString() + ".parquet";
-        properties.setDestinationTableName(destinationTableName);
-        properties.setDiffsFilePath("'" + diffsFilePath + "'");
-        String boundaryCondition =
-            swiftLakeEngine.getSchemaEvolution().getDuckDBFilterSql(table, tableFilter);
-        properties.setBoundaryCondition(boundaryCondition);
+      if (properties.getMode() == SCD1MergeMode.CHANGES) {
+        // Handle non-append-only scenario
+        if (!isAppendOnly) {
+          properties.setDestinationTableName(destinationTableName);
+          properties.setDiffsFilePath("'" + diffsFilePath + "'");
 
-        scd1MergeDao.mergeFindDiffs(properties);
+          scd1MergeDao.changesBasedMergeFindDiffs(properties);
 
-        boolean emptyDiffs = FileUtil.isEmptyFolder(diffsFilePath);
-        if (!emptyDiffs) {
+          boolean emptyDiffs = FileUtil.isEmptyFolder(diffsFilePath);
+          if (!emptyDiffs) {
+            WriteUtil.uploadDebugFiles(
+                fileIO,
+                swiftLakeEngine.getDebugFileUploadPath(),
+                diffsFilePath,
+                diffsFileBaseFolder);
+            properties.setDiffsFilePath(getDiffsTableName(diffsFilePath));
+            properties.setModifiedFileNamesFilePath(modifiedFileNamesFilePath);
+            scd1MergeDao.saveDistinctFileNamesForChangesMerge(properties);
+
+            WriteUtil.checkMergeCardinality(commonDao, properties.getDiffsFilePath());
+
+            modifiedFiles = scd1MergeDao.getFileNames(modifiedFileNamesFilePath);
+          } else {
+            properties.setDiffsFilePath(null);
+          }
+        }
+
+        // Generate merge results SQL
+        mergeResultsSql = scd1MergeDao.getChangesBasedMergeResultsSql(properties);
+
+      } else if (properties.getMode() == SCD1MergeMode.SNAPSHOT) {
+        if (!properties.isAppendOnly()) {
+          properties.setDestinationTableName(destinationTableName);
+          properties.setDiffsFilePath("'" + diffsFilePath + "'");
+
+          scd1MergeDao.snapshotBasedMergeFindDiffs(properties);
+
+          if (FileUtil.isEmptyFolder(diffsFilePath)) {
+            LOGGER.info("No changes to apply.");
+            return null;
+          }
+          WriteUtil.uploadDebugFiles(
+              fileIO, swiftLakeEngine.getDebugFileUploadPath(), diffsFilePath, diffsFileBaseFolder);
           properties.setDiffsFilePath(getDiffsTableName(diffsFilePath));
           properties.setModifiedFileNamesFilePath(modifiedFileNamesFilePath);
-          scd1MergeDao.saveDistinctFileNames(properties);
+          scd1MergeDao.saveDistinctFileNamesForSnapshotMerge(properties);
 
           WriteUtil.checkMergeCardinality(commonDao, properties.getDiffsFilePath());
 
           modifiedFiles = scd1MergeDao.getFileNames(modifiedFileNamesFilePath);
+        }
+
+        if (properties.isAppendOnly()) {
+          mergeResultsSql = scd1MergeDao.getSnapshotBasedMergeAppendOnlySql(properties);
         } else {
-          properties.setDiffsFilePath(null);
+          mergeResultsSql = scd1MergeDao.getSnapshotBasedMergeResultsSql(properties);
         }
       }
 
-      // Generate upserts SQL
-      String upsertsSql = scd1MergeDao.getMergeUpsertsSql(properties);
-
+      boolean isPartitionedTable = table.spec().isPartitioned();
       List<com.arcesium.swiftlake.common.DataFile> newFiles;
       if (isPartitionedTable) {
         // Handle partitioned table
@@ -263,14 +325,14 @@ public class SCD1Merge {
 
         newFiles =
             PartitionedDataFileWriter.builderFor(
-                    swiftLakeEngine, table, partitionDataSql, upsertsSql)
+                    swiftLakeEngine, table, partitionDataSql, mergeResultsSql)
                 .skipDataSorting(properties.isSkipDataSorting())
                 .build()
                 .write();
       } else {
         // Handle unpartitioned table
         newFiles =
-            UnpartitionedDataFileWriter.builderFor(swiftLakeEngine, table, upsertsSql)
+            UnpartitionedDataFileWriter.builderFor(swiftLakeEngine, table, mergeResultsSql)
                 .skipDataSorting(properties.isSkipDataSorting())
                 .build()
                 .write();
@@ -368,6 +430,95 @@ public class SCD1Merge {
         properties.getMybatisStatementParameter());
   }
 
+  private void validateColumns(
+      List<String> allColumns,
+      List<String> keyColumns,
+      List<String> valueColumns,
+      Map<String, ValueColumnMetadata<?>> valueColumnMetadataMap) {
+    Set<String> allColumnsSet = new HashSet<>(allColumns);
+
+    for (String column : keyColumns) {
+      ValidationException.check(allColumnsSet.contains(column), "Invalid key column %s", column);
+    }
+    Set<String> keyColumnsSet = new HashSet<>(keyColumns);
+    if (valueColumns != null && !valueColumns.isEmpty()) {
+      for (String column : valueColumns) {
+        ValidationException.check(
+            allColumnsSet.contains(column), "Invalid value column %s", column);
+        ValidationException.check(
+            !keyColumnsSet.contains(column),
+            "Column '%s' cannot be both a key column and a value column",
+            column);
+      }
+    }
+    if (valueColumnMetadataMap != null) {
+      Set<String> valueColumnSet =
+          valueColumns != null ? new HashSet<>(valueColumns) : new HashSet<>();
+
+      for (Map.Entry<String, ValueColumnMetadata<?>> entry : valueColumnMetadataMap.entrySet()) {
+        ValidationException.check(
+            valueColumnSet.contains(entry.getKey()), "Invalid value column %s", entry.getKey());
+        ValidationException.check(
+            entry.getValue().getMaxDeltaValue() == null
+                || entry.getValue().getNullReplacement() == null,
+            "Provide either max delta value or null value for the value column %s",
+            entry.getKey());
+      }
+    }
+  }
+
+  private void validateChangesMode() {
+    // Check if delete operation value is provided without an operation type column
+    if (properties.getOperationTypeColumn() == null
+        && properties.getDeleteOperationValue() != null
+        && !properties.getDeleteOperationValue().isBlank()) {
+      throw new ValidationException(
+          "Operation type column must be specified when delete operation value is provided");
+    }
+    if (properties.getOperationTypeColumn() != null) {
+      ValidationException.check(
+          !properties.getOperationTypeColumn().isBlank(), "Operation type column cannot be empty.");
+      ValidationException.check(
+          properties.getDeleteOperationValue() != null
+              && !properties.getDeleteOperationValue().isBlank(),
+          "Delete operation value is mandatory.");
+      properties.setOperationTypeColumn(
+          swiftLakeEngine
+              .getSchemaEvolution()
+              .escapeColumnName(properties.getOperationTypeColumn()));
+      properties.setDeleteOperationValue(
+          swiftLakeEngine
+              .getSchemaEvolution()
+              .getPrimitiveTypeStringValueForSql(
+                  Types.StringType.get(), properties.getDeleteOperationValue(), true));
+    }
+  }
+
+  private void processValueColumnMetadata(Schema schema) {
+    if (properties.getValueColumnMetadataMap() == null
+        || properties.getValueColumnMetadataMap().isEmpty()) {
+      return;
+    }
+    properties.setValueColumnMaxDeltaValues(
+        properties.getValueColumnMetadataMap().entrySet().stream()
+            .filter(e -> e.getValue() != null && e.getValue().getMaxDeltaValue() != null)
+            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getMaxDeltaValue())));
+    properties.setValueColumnNullReplacements(
+        properties.getValueColumnMetadataMap().entrySet().stream()
+            .filter(e -> e.getValue() != null && e.getValue().getNullReplacement() != null)
+            .map(
+                e -> {
+                  String nullValue =
+                      swiftLakeEngine
+                          .getSchemaEvolution()
+                          .getPrimitiveTypeValueForSql(
+                              schema.findField(e.getKey()).type().asPrimitiveType(),
+                              e.getValue().getNullReplacement());
+                  return Pair.of(e.getKey(), nullValue);
+                })
+            .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
+  }
+
   /**
    * Applies changes as SCD1 (Slowly Changing Dimension Type 1) merge operation.
    *
@@ -400,6 +551,42 @@ public class SCD1Merge {
   public static SetTableFilter applyChanges(
       SwiftLakeEngine swiftLakeEngine, TableBatchTransaction tableBatchTransaction) {
     return new BuilderImpl(swiftLakeEngine, tableBatchTransaction);
+  }
+
+  /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) merge operation.
+   *
+   * @param swiftLakeEngine The SwiftLakeEngine instance
+   * @param tableName The name of the table to apply the snapshot to
+   * @return A SnapshotModeSetTableFilter instance for further configuration
+   */
+  public static SnapshotModeSetTableFilter applySnapshot(
+      SwiftLakeEngine swiftLakeEngine, String tableName) {
+    return new SnapshotModeBuilderImpl(swiftLakeEngine, swiftLakeEngine.getTable(tableName, true));
+  }
+
+  /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) merge operation.
+   *
+   * @param swiftLakeEngine The SwiftLakeEngine instance
+   * @param table The Table instance to apply the snapshot to
+   * @return A SnapshotModeSetTableFilter instance for further configuration
+   */
+  public static SnapshotModeSetTableFilter applySnapshot(
+      SwiftLakeEngine swiftLakeEngine, Table table) {
+    return new SnapshotModeBuilderImpl(swiftLakeEngine, table);
+  }
+
+  /**
+   * Applies a snapshot as SCD1 (Slowly Changing Dimension Type 1) merge operation.
+   *
+   * @param swiftLakeEngine The SwiftLakeEngine instance
+   * @param tableBatchTransaction The TableBatchTransaction instance to apply the snapshot to
+   * @return A SnapshotModeSetTableFilter instance for further configuration
+   */
+  public static SnapshotModeSetTableFilter applySnapshot(
+      SwiftLakeEngine swiftLakeEngine, TableBatchTransaction tableBatchTransaction) {
+    return new SnapshotModeBuilderImpl(swiftLakeEngine, tableBatchTransaction);
   }
 
   public interface SetTableFilter {
@@ -567,6 +754,7 @@ public class SCD1Merge {
       this.swiftLakeEngine = swiftLakeEngine;
       this.table = table;
       this.properties = new SCD1MergeProperties();
+      this.properties.setMode(SCD1MergeMode.CHANGES);
       this.properties.setSqlSessionFactory(swiftLakeEngine.getSqlSessionFactory());
       this.properties.setProcessSourceTables(swiftLakeEngine.getProcessTablesDefaultValue());
     }
@@ -583,6 +771,7 @@ public class SCD1Merge {
       this.swiftLakeEngine = swiftLakeEngine;
       this.table = tableBatchTransaction.getTable();
       this.properties = new SCD1MergeProperties();
+      this.properties.setMode(SCD1MergeMode.CHANGES);
       this.properties.setSqlSessionFactory(swiftLakeEngine.getSqlSessionFactory());
       this.tableBatchTransaction = tableBatchTransaction;
       this.properties.setProcessSourceTables(swiftLakeEngine.getProcessTablesDefaultValue());
@@ -640,6 +829,8 @@ public class SCD1Merge {
 
     @Override
     public Builder keyColumns(List<String> keyColumns) {
+      ValidationException.check(
+          keyColumns != null && !keyColumns.isEmpty(), "Key columns cannot be null or empty");
       properties.setKeyColumns(keyColumns.stream().distinct().collect(Collectors.toList()));
       return this;
     }
@@ -691,6 +882,362 @@ public class SCD1Merge {
 
     @Override
     public Builder isolationLevel(IsolationLevel isolationLevel) {
+      ValidationException.check(
+          isolationLevel == null || tableBatchTransaction == null,
+          "Set isolation level on the batch transaction.");
+      this.isolationLevel = isolationLevel;
+      return this;
+    }
+
+    @Override
+    public CommitMetrics execute() {
+      SCD1Merge merge =
+          new SCD1Merge(
+              swiftLakeEngine,
+              table,
+              properties,
+              tableBatchTransaction,
+              branch,
+              snapshotMetadata,
+              isolationLevel);
+      return merge.execute();
+    }
+  }
+
+  public interface SnapshotModeSetTableFilter {
+    /**
+     * Sets a table filter using an Expression condition.
+     *
+     * @param condition The Expression to use as a filter condition
+     * @return SnapshotModeSetSourceData interface for further configuration
+     */
+    SnapshotModeSetSourceData tableFilter(Expression condition);
+
+    /**
+     * Sets a table filter using a SQL condition string.
+     *
+     * @param conditionSql The SQL string to use as a filter condition
+     * @return SnapshotModeSetSourceData interface for further configuration
+     */
+    SnapshotModeSetSourceData tableFilterSql(String conditionSql);
+  }
+
+  public interface SnapshotModeSetSourceData {
+    /**
+     * Sets the source SQL for the merge operation.
+     *
+     * @param sql The SQL string to use as the source
+     * @return SnapshotModeSetKeyColumns interface for further configuration
+     */
+    SnapshotModeSetKeyColumns sourceSql(String sql);
+
+    /**
+     * Sets the source using a MyBatis statement ID.
+     *
+     * @param id The ID of the MyBatis statement to use as the source
+     * @return SnapshotModeSetKeyColumns interface for further configuration
+     */
+    SnapshotModeSetKeyColumns sourceMybatisStatement(String id);
+
+    /**
+     * Sets the source using a MyBatis statement ID and a parameter object.
+     *
+     * @param id The ID of the MyBatis statement to use as the source
+     * @param parameter The parameter object to pass to the MyBatis statement
+     * @return SnapshotModeSetKeyColumns interface for further configuration
+     */
+    SnapshotModeSetKeyColumns sourceMybatisStatement(String id, Object parameter);
+  }
+
+  public interface SnapshotModeSetKeyColumns {
+    /**
+     * Sets the key columns for the merge operation.
+     *
+     * @param keyColumns The list of column names to use as key columns
+     * @return SnapshotModeBuilder interface for further configuration
+     */
+    SnapshotModeBuilder keyColumns(List<String> keyColumns);
+  }
+
+  public interface SnapshotModeBuilder {
+    /**
+     * Sets the columns to be included in the merge operation.
+     *
+     * @param columns The list of column names to include
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder columns(List<String> columns);
+
+    /**
+     * Sets the columns to be used for values.
+     *
+     * @param valueColumns List of value column names
+     * @return This SnapshotModeBuilder instance
+     */
+    SnapshotModeBuilder valueColumns(List<String> valueColumns);
+
+    /**
+     * Sets the metadata for multiple value columns.
+     *
+     * @param metadataMap Map of column names to their respective ValueColumnMetadata
+     * @return This SnapshotModeBuilder instance
+     */
+    SnapshotModeBuilder valueColumnsMetadata(Map<String, ValueColumnMetadata<?>> metadataMap);
+
+    /**
+     * Sets the metadata for a single value column.
+     *
+     * @param column The column name
+     * @param metadata The ValueColumnMetadata for the column
+     * @return This SnapshotModeBuilder instance
+     */
+    <T> SnapshotModeBuilder valueColumnMetadata(String column, ValueColumnMetadata<T> metadata);
+
+    /**
+     * Sets the SwiftLakeSqlSessionFactory to be used.
+     *
+     * @param sqlSessionFactory The SwiftLakeSqlSessionFactory instance
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder sqlSessionFactory(SwiftLakeSqlSessionFactory sqlSessionFactory);
+
+    /**
+     * Configures whether to skip empty source data.
+     *
+     * @param skipEmptySource True to skip empty source data, false otherwise
+     * @return This SnapshotModeBuilder instance
+     */
+    SnapshotModeBuilder skipEmptySource(boolean skipEmptySource);
+
+    /**
+     * Sets whether to skip data sorting.
+     *
+     * @param skipDataSorting true to skip data sorting, false otherwise
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder skipDataSorting(boolean skipDataSorting);
+
+    /**
+     * Sets whether to execute the source SQL only once.
+     *
+     * @param executeSourceSqlOnceOnly true to execute source SQL once only, false otherwise
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder executeSourceSqlOnceOnly(boolean executeSourceSqlOnceOnly);
+
+    /**
+     * Sets the branch name.
+     *
+     * @param branch The name of the branch
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder branch(String branch);
+
+    /**
+     * Sets the snapshot metadata.
+     *
+     * @param snapshotMetadata A map containing snapshot metadata
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder snapshotMetadata(Map<String, String> snapshotMetadata);
+
+    /**
+     * Sets the isolation level for the merge operation.
+     *
+     * @param isolationLevel The IsolationLevel to be used
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder isolationLevel(IsolationLevel isolationLevel);
+
+    /**
+     * Sets whether to process source tables.
+     *
+     * @param processSourceTables true to process source tables, false otherwise
+     * @return This SnapshotModeBuilder instance for method chaining
+     */
+    SnapshotModeBuilder processSourceTables(boolean processSourceTables);
+
+    /**
+     * Executes the SCD1Merge operation with the configured settings.
+     *
+     * @return CommitMetrics containing metrics about the executed merge operation
+     */
+    CommitMetrics execute();
+  }
+
+  /** Implementation of the Builder pattern for SCD1Merge. */
+  public static class SnapshotModeBuilderImpl
+      implements SnapshotModeSetSourceData,
+          SnapshotModeSetTableFilter,
+          SnapshotModeSetKeyColumns,
+          SnapshotModeBuilder {
+    private final SwiftLakeEngine swiftLakeEngine;
+    private final Table table;
+    private final SCD1MergeProperties properties;
+    private TableBatchTransaction tableBatchTransaction;
+    private String branch;
+    private Map<String, String> snapshotMetadata;
+    private IsolationLevel isolationLevel;
+
+    /**
+     * Constructs a new SnapshotModeBuilderImpl instance.
+     *
+     * @param swiftLakeEngine The SwiftLakeEngine instance to be used.
+     * @param table The Table instance to be associated with this builder.
+     */
+    private SnapshotModeBuilderImpl(SwiftLakeEngine swiftLakeEngine, Table table) {
+      this.swiftLakeEngine = swiftLakeEngine;
+      this.table = table;
+      this.properties = new SCD1MergeProperties();
+      this.properties.setMode(SCD1MergeMode.SNAPSHOT);
+      this.properties.setSqlSessionFactory(swiftLakeEngine.getSqlSessionFactory());
+      this.properties.setProcessSourceTables(swiftLakeEngine.getProcessTablesDefaultValue());
+      this.properties.setValueColumnMetadataMap(new HashMap<>());
+    }
+
+    /**
+     * Constructs a new BuilderImpl instance with a TableBatchTransaction.
+     *
+     * @param swiftLakeEngine The SwiftLakeEngine instance to be used.
+     * @param tableBatchTransaction The TableBatchTransaction instance to be associated with this
+     *     builder.
+     */
+    private SnapshotModeBuilderImpl(
+        SwiftLakeEngine swiftLakeEngine, TableBatchTransaction tableBatchTransaction) {
+      this.swiftLakeEngine = swiftLakeEngine;
+      this.table = tableBatchTransaction.getTable();
+      this.properties = new SCD1MergeProperties();
+      this.properties.setMode(SCD1MergeMode.SNAPSHOT);
+      this.properties.setSqlSessionFactory(swiftLakeEngine.getSqlSessionFactory());
+      this.tableBatchTransaction = tableBatchTransaction;
+      this.properties.setProcessSourceTables(swiftLakeEngine.getProcessTablesDefaultValue());
+      this.properties.setValueColumnMetadataMap(new HashMap<>());
+    }
+
+    @Override
+    public SnapshotModeSetSourceData tableFilter(Expression filter) {
+      properties.setTableFilter(filter);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeSetSourceData tableFilterSql(String conditionSql) {
+      properties.setTableFilterSql(conditionSql);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeSetKeyColumns sourceSql(String sql) {
+      properties.setSql(sql);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeSetKeyColumns sourceMybatisStatement(String id) {
+      properties.setMybatisStatementId(id);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeSetKeyColumns sourceMybatisStatement(String id, Object parameter) {
+      properties.setMybatisStatementId(id);
+      properties.setMybatisStatementParameter(parameter);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder processSourceTables(boolean processSourceTables) {
+      properties.setProcessSourceTables(processSourceTables);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder sqlSessionFactory(SwiftLakeSqlSessionFactory sqlSessionFactory) {
+      properties.setSqlSessionFactory(sqlSessionFactory);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder keyColumns(List<String> keyColumns) {
+      ValidationException.check(
+          keyColumns != null && !keyColumns.isEmpty(), "Key columns cannot be null or empty");
+      properties.setKeyColumns(keyColumns.stream().distinct().collect(Collectors.toList()));
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder columns(List<String> columns) {
+      properties.setColumns(
+          columns == null ? null : columns.stream().distinct().collect(Collectors.toList()));
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder valueColumns(List<String> valueColumns) {
+      properties.setValueColumns(
+          valueColumns == null
+              ? null
+              : valueColumns.stream().distinct().collect(Collectors.toList()));
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder valueColumnsMetadata(
+        Map<String, ValueColumnMetadata<?>> metadataMap) {
+      if (metadataMap != null) {
+        properties.getValueColumnMetadataMap().putAll(metadataMap);
+      }
+      return this;
+    }
+
+    @Override
+    public <T> SnapshotModeBuilder valueColumnMetadata(
+        String column, ValueColumnMetadata<T> metadata) {
+      ValidationException.checkNotNull(column, "Column name cannot be null");
+      ValidationException.checkNotNull(metadata, "Column metadata cannot be null");
+      properties.getValueColumnMetadataMap().put(column, metadata);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder skipEmptySource(boolean skipEmptySource) {
+      properties.setSkipEmptySource(skipEmptySource);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder skipDataSorting(boolean skipDataSorting) {
+      properties.setSkipDataSorting(skipDataSorting);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder executeSourceSqlOnceOnly(boolean executeSourceSqlOnceOnly) {
+      properties.setExecuteSourceSqlOnceOnly(executeSourceSqlOnceOnly);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder branch(String branch) {
+      ValidationException.check(
+          branch == null || tableBatchTransaction == null,
+          "Set branch name on the batch transaction.");
+      this.branch = branch;
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder snapshotMetadata(Map<String, String> snapshotMetadata) {
+      ValidationException.check(
+          snapshotMetadata == null || tableBatchTransaction == null,
+          "Set snapshot metadata on the batch transaction.");
+      this.snapshotMetadata =
+          snapshotMetadata == null ? null : ImmutableMap.copyOf(snapshotMetadata);
+      return this;
+    }
+
+    @Override
+    public SnapshotModeBuilder isolationLevel(IsolationLevel isolationLevel) {
       ValidationException.check(
           isolationLevel == null || tableBatchTransaction == null,
           "Set isolation level on the batch transaction.");

--- a/core/src/main/java/com/arcesium/swiftlake/commands/SCD1MergeMode.java
+++ b/core/src/main/java/com/arcesium/swiftlake/commands/SCD1MergeMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, Arcesium LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arcesium.swiftlake.commands;
+
+/** Enum representing the modes of SCD1 (Slowly Changing Dimension Type 1) merge operations. */
+public enum SCD1MergeMode {
+  /** Represents a snapshot mode for SCD1 merge. */
+  SNAPSHOT,
+  /** Represents a changes-only mode for SCD1 merge. */
+  CHANGES
+}

--- a/core/src/main/java/com/arcesium/swiftlake/commands/SCD1MergeProperties.java
+++ b/core/src/main/java/com/arcesium/swiftlake/commands/SCD1MergeProperties.java
@@ -18,9 +18,11 @@ package com.arcesium.swiftlake.commands;
 import com.arcesium.swiftlake.expressions.Expression;
 import com.arcesium.swiftlake.mybatis.SwiftLakeSqlSessionFactory;
 import java.util.List;
+import java.util.Map;
 
 /** Represents properties for SCD1 (Slowly Changing Dimension Type 1) merge operations. */
 public class SCD1MergeProperties {
+  private SCD1MergeMode mode;
   private Expression tableFilter;
   private String tableFilterSql;
   private List<String> tableFilterColumns;
@@ -31,9 +33,12 @@ public class SCD1MergeProperties {
   private SwiftLakeSqlSessionFactory sqlSessionFactory;
   private boolean executeSourceSqlOnceOnly;
   private List<String> keyColumns;
+  private List<String> valueColumns;
+  private Map<String, ValueColumnMetadata<?>> valueColumnMetadataMap;
   private List<String> columns;
   private String operationTypeColumn;
   private String deleteOperationValue;
+  private boolean skipEmptySource;
   private boolean skipDataSorting;
 
   // Internal
@@ -45,8 +50,18 @@ public class SCD1MergeProperties {
   private boolean appendOnly;
   private String compression;
   private String modifiedFileNamesFilePath;
+  private Map<String, Double> valueColumnMaxDeltaValues;
+  private Map<String, String> valueColumnNullReplacements;
 
   public SCD1MergeProperties() {}
+
+  public SCD1MergeMode getMode() {
+    return mode;
+  }
+
+  public void setMode(SCD1MergeMode mode) {
+    this.mode = mode;
+  }
 
   public Expression getTableFilter() {
     return tableFilter;
@@ -78,6 +93,23 @@ public class SCD1MergeProperties {
 
   public void setKeyColumns(List<String> keyColumns) {
     this.keyColumns = keyColumns;
+  }
+
+  public List<String> getValueColumns() {
+    return valueColumns;
+  }
+
+  public void setValueColumns(List<String> valueColumns) {
+    this.valueColumns = valueColumns;
+  }
+
+  public Map<String, ValueColumnMetadata<?>> getValueColumnMetadataMap() {
+    return valueColumnMetadataMap;
+  }
+
+  public void setValueColumnMetadataMap(
+      Map<String, ValueColumnMetadata<?>> valueColumnMetadataMap) {
+    this.valueColumnMetadataMap = valueColumnMetadataMap;
   }
 
   public List<String> getColumns() {
@@ -192,6 +224,14 @@ public class SCD1MergeProperties {
     this.executeSourceSqlOnceOnly = executeSourceSqlOnceOnly;
   }
 
+  public boolean isSkipEmptySource() {
+    return skipEmptySource;
+  }
+
+  public void setSkipEmptySource(boolean skipEmptySource) {
+    this.skipEmptySource = skipEmptySource;
+  }
+
   public boolean isSkipDataSorting() {
     return skipDataSorting;
   }
@@ -224,10 +264,28 @@ public class SCD1MergeProperties {
     this.processSourceTables = processSourceTables;
   }
 
+  public Map<String, Double> getValueColumnMaxDeltaValues() {
+    return valueColumnMaxDeltaValues;
+  }
+
+  public void setValueColumnMaxDeltaValues(Map<String, Double> valueColumnMaxDeltaValues) {
+    this.valueColumnMaxDeltaValues = valueColumnMaxDeltaValues;
+  }
+
+  public Map<String, String> getValueColumnNullReplacements() {
+    return valueColumnNullReplacements;
+  }
+
+  public void setValueColumnNullReplacements(Map<String, String> valueColumnNullReplacements) {
+    this.valueColumnNullReplacements = valueColumnNullReplacements;
+  }
+
   @Override
   public String toString() {
     return "MergeProperties{"
-        + "tableFilter="
+        + "mode="
+        + mode
+        + ", tableFilter="
         + tableFilter
         + ", tableFilterSql='"
         + tableFilterSql
@@ -248,6 +306,10 @@ public class SCD1MergeProperties {
         + executeSourceSqlOnceOnly
         + ", keyColumns="
         + keyColumns
+        + ", valueColumns="
+        + valueColumns
+        + ", valueColumnMetadataMap="
+        + valueColumnMetadataMap
         + ", columns="
         + columns
         + ", operationColumnName='"
@@ -256,6 +318,8 @@ public class SCD1MergeProperties {
         + ", deleteOperationValue='"
         + deleteOperationValue
         + '\''
+        + ", skipEmptySource="
+        + skipEmptySource
         + ", skipDataSorting="
         + skipDataSorting
         + ", boundaryCondition='"

--- a/core/src/main/java/com/arcesium/swiftlake/commands/ValueColumnMetadata.java
+++ b/core/src/main/java/com/arcesium/swiftlake/commands/ValueColumnMetadata.java
@@ -16,21 +16,21 @@
 package com.arcesium.swiftlake.commands;
 
 /**
- * This class represents metadata for change tracking in SwiftLake operations.
+ * This class represents metadata for value columns in SwiftLake operations.
  *
  * @param <T> The type of the null replacement value
  */
-public class ChangeTrackingMetadata<T> {
-  private Double maxDeltaValue; // Numeric tolerance for comparisons
+public class ValueColumnMetadata<T> {
+  private Double maxDeltaValue; // Numeric tolerance for value comparisons
   private T nullReplacement; // Value to use for NULL during comparison
 
   /**
-   * Constructs a new ChangeTrackingMetadata instance.
+   * Constructs a new ValueColumnsMetadata instance.
    *
    * @param maxDeltaValue The maximum delta value for numeric change tolerance
    * @param nullReplacement The replacement value for null values
    */
-  public ChangeTrackingMetadata(Double maxDeltaValue, T nullReplacement) {
+  public ValueColumnMetadata(Double maxDeltaValue, T nullReplacement) {
     this.maxDeltaValue = maxDeltaValue;
     this.nullReplacement = nullReplacement;
   }
@@ -54,13 +54,13 @@ public class ChangeTrackingMetadata<T> {
   }
 
   /**
-   * Returns a string representation of the ChangeTrackingMetadata object.
+   * Returns a string representation of the ValueColumnsMetadata object.
    *
    * @return A string representation of the object
    */
   @Override
   public String toString() {
-    return "ChangeTrackingMetadata{"
+    return "ValueColumnsMetadata{"
         + "maxDeltaValue="
         + maxDeltaValue
         + ", nullReplacement="

--- a/core/src/main/java/com/arcesium/swiftlake/common/DateTimeUtil.java
+++ b/core/src/main/java/com/arcesium/swiftlake/common/DateTimeUtil.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025, Arcesium LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arcesium.swiftlake.common;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+
+/** Utility class for date and time operations */
+public class DateTimeUtil {
+  private DateTimeUtil() {}
+
+  /**
+   * Parses a string representation into a LocalDate using ISO_LOCAL_DATE format.
+   *
+   * @param value The string to parse (e.g., "2023-12-31")
+   * @return The parsed LocalDate
+   * @throws ValidationException if the string cannot be parsed as a valid ISO date
+   */
+  public static LocalDate parseLocalDate(String value) {
+    ValidationException.checkNotNull(value, "Date string cannot be null");
+    if (value.trim().isEmpty()) {
+      throw new ValidationException("Date string cannot be empty");
+    }
+
+    try {
+      return LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE);
+    } catch (DateTimeParseException e) {
+      throw new ValidationException(
+          "Date '%s' must be in ISO format (yyyy-MM-dd, e.g., 2023-12-31)", value);
+    }
+  }
+
+  /**
+   * Parses a string representation into a LocalTime with microsecond precision. Any nanosecond
+   * precision beyond microseconds will be truncated.
+   *
+   * @param value The string to parse (e.g., "14:30:45.123456")
+   * @return The parsed LocalTime truncated to microsecond precision
+   * @throws ValidationException if the string cannot be parsed as a valid ISO time
+   */
+  public static LocalTime parseLocalTimeToMicros(String value) {
+    ValidationException.checkNotNull(value, "Time string cannot be null");
+    if (value.trim().isEmpty()) {
+      throw new ValidationException("Time string cannot be empty");
+    }
+
+    try {
+      return LocalTime.parse(value, DateTimeFormatter.ISO_LOCAL_TIME)
+          .truncatedTo(ChronoUnit.MICROS);
+    } catch (DateTimeParseException e) {
+      throw new ValidationException(
+          "Time '%s' must be in ISO format (HH:mm:ss[.SSSSSS], e.g., 14:30:45.123456)", value);
+    }
+  }
+
+  /**
+   * Parses a string representation into a LocalDateTime with microsecond precision. Any nanosecond
+   * precision beyond microseconds will be truncated.
+   *
+   * @param value The string to parse (e.g., "2023-12-31T14:30:45.123456")
+   * @return The parsed LocalDateTime truncated to microsecond precision
+   * @throws ValidationException if the string cannot be parsed as a valid ISO date-time
+   */
+  public static LocalDateTime parseLocalDateTimeToMicros(String value) {
+    ValidationException.checkNotNull(value, "Timestamp string cannot be null");
+    if (value.trim().isEmpty()) {
+      throw new ValidationException("Timestamp string cannot be empty");
+    }
+
+    try {
+      return LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+          .truncatedTo(ChronoUnit.MICROS);
+    } catch (DateTimeParseException e) {
+      throw new ValidationException(
+          "Timestamp '%s' must be in ISO format (yyyy-MM-ddTHH:mm:ss[.SSSSSS], e.g., 2023-12-31T14:30:45.123456)",
+          value);
+    }
+  }
+
+  /**
+   * Parses a string representation into an OffsetDateTime with microsecond precision. Any
+   * nanosecond precision beyond microseconds will be truncated.
+   *
+   * @param value The string to parse (e.g., "2023-12-31T14:30:45.123456+01:00")
+   * @return The parsed OffsetDateTime truncated to microsecond precision
+   * @throws ValidationException if the string cannot be parsed as a valid ISO offset date-time
+   */
+  public static OffsetDateTime parseOffsetDateTimeToMicros(String value) {
+    ValidationException.checkNotNull(value, "TimestampTZ string cannot be null");
+    if (value.trim().isEmpty()) {
+      throw new ValidationException("TimestampTZ string cannot be empty");
+    }
+
+    try {
+      return OffsetDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .truncatedTo(ChronoUnit.MICROS);
+    } catch (DateTimeParseException e) {
+      throw new ValidationException(
+          "TimestampTZ '%s' must be in ISO format (yyyy-MM-ddTHH:mm:ss[.SSSSSS]±HH:MM, e.g., 2023-12-31T14:30:45.123456+01:00)",
+          value);
+    }
+  }
+
+  /**
+   * Formats a LocalDate to ISO date string.
+   *
+   * @param value The LocalDate to format
+   * @return The formatted date string (e.g., "2023-12-31")
+   */
+  public static String formatLocalDate(LocalDate value) {
+    ValidationException.checkNotNull(value, "Date value cannot be null");
+    return DateTimeFormatter.ISO_LOCAL_DATE.format(value);
+  }
+
+  /**
+   * Formats a LocalTime to ISO time string with microsecond precision.
+   *
+   * @param value The LocalTime to format
+   * @return The formatted time string with microsecond precision (e.g., "14:30:45.123456")
+   */
+  public static String formatLocalTimeWithMicros(LocalTime value) {
+    ValidationException.checkNotNull(value, "Time value cannot be null");
+    return DateTimeFormatter.ISO_LOCAL_TIME.format(value.truncatedTo(ChronoUnit.MICROS));
+  }
+
+  /**
+   * Formats a LocalDateTime to ISO date-time string with microsecond precision.
+   *
+   * @param value The LocalDateTime to format
+   * @return The formatted date-time string with microsecond precision (e.g.,
+   *     "2023-12-31T14:30:45.123456")
+   */
+  public static String formatLocalDateTimeWithMicros(LocalDateTime value) {
+    ValidationException.checkNotNull(value, "Timestamp value cannot be null");
+    return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(value.truncatedTo(ChronoUnit.MICROS));
+  }
+
+  /**
+   * Formats an OffsetDateTime to ISO offset date-time string with microsecond precision.
+   *
+   * @param value The OffsetDateTime to format
+   * @return The formatted offset date-time string with microsecond precision (e.g.,
+   *     "2023-12-31T14:30:45.123456+01:00")
+   */
+  public static String formatOffsetDateTimeWithMicros(OffsetDateTime value) {
+    ValidationException.checkNotNull(value, "TimestampTZ value cannot be null");
+    return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(value.truncatedTo(ChronoUnit.MICROS));
+  }
+}

--- a/core/src/main/java/com/arcesium/swiftlake/dao/SCD1MergeDao.java
+++ b/core/src/main/java/com/arcesium/swiftlake/dao/SCD1MergeDao.java
@@ -41,9 +41,9 @@ public class SCD1MergeDao extends BaseDao {
    *
    * @param properties The SCD1MergeProperties containing configuration for the merge operation.
    */
-  public void mergeFindDiffs(SCD1MergeProperties properties) {
+  public void changesBasedMergeFindDiffs(SCD1MergeProperties properties) {
     try (SqlSession session = getSession()) {
-      session.update(namespace + ".mergeFindDiffs", properties);
+      session.update(namespace + ".changesBasedMergeFindDiffs", properties);
     }
   }
 
@@ -53,8 +53,8 @@ public class SCD1MergeDao extends BaseDao {
    * @param properties The SCD1MergeProperties containing configuration for the merge operation.
    * @return A String containing the SQL for merging changes.
    */
-  public String getMergeUpsertsSql(SCD1MergeProperties properties) {
-    return getSql(namespace + ".mergeUpserts", properties);
+  public String getChangesBasedMergeResultsSql(SCD1MergeProperties properties) {
+    return getSql(namespace + ".changesBasedMergeResults", properties);
   }
 
   /**
@@ -74,9 +74,52 @@ public class SCD1MergeDao extends BaseDao {
    *
    * @param properties The SCD1MergeProperties containing configuration for the operation.
    */
-  public void saveDistinctFileNames(SCD1MergeProperties properties) {
+  public void saveDistinctFileNamesForChangesMerge(SCD1MergeProperties properties) {
     try (SqlSession session = getSession()) {
-      session.update(namespace + ".saveDistinctFileNames", properties);
+      session.update(namespace + ".saveDistinctFileNamesForChangesMerge", properties);
+    }
+  }
+
+  /**
+   * Identifies differences between source and target data for SCD1 snapshot-based merge operation.
+   *
+   * @param properties The SCD1MergeProperties containing configuration for the snapshot merge
+   *     operation.
+   */
+  public void snapshotBasedMergeFindDiffs(SCD1MergeProperties properties) {
+    try (SqlSession session = getSession()) {
+      session.update(namespace + ".snapshotBasedMergeFindDiffs", properties);
+    }
+  }
+
+  /**
+   * Retrieves the SQL for append-only operations in snapshot-based SCD1 merge.
+   *
+   * @param properties The SCD1MergeProperties containing configuration for the operation.
+   * @return A String containing the SQL for append-only operations.
+   */
+  public String getSnapshotBasedMergeAppendOnlySql(SCD1MergeProperties properties) {
+    return getSql(namespace + ".snapshotBasedMergeAppendOnly", properties);
+  }
+
+  /**
+   * Retrieves the SQL for merging snapshot in the SCD1 process.
+   *
+   * @param properties The SCD1MergeProperties containing configuration for the operation.
+   * @return A String containing the SQL for merging snapshot.
+   */
+  public String getSnapshotBasedMergeResultsSql(SCD1MergeProperties properties) {
+    return getSql(namespace + ".snapshotBasedMergeResults", properties);
+  }
+
+  /**
+   * Saves distinct file names for snapshot-based merge based on the provided properties.
+   *
+   * @param properties The SCD1MergeProperties containing configuration for the operation.
+   */
+  public void saveDistinctFileNamesForSnapshotMerge(SCD1MergeProperties properties) {
+    try (SqlSession session = getSession()) {
+      session.update(namespace + ".saveDistinctFileNamesForSnapshotMerge", properties);
     }
   }
 }

--- a/core/src/main/resources/dao/common.xml
+++ b/core/src/main/resources/dao/common.xml
@@ -18,30 +18,6 @@
         </foreach>
     </sql>
 
-    <sql id="changeTrackingColumnsDiff">
-        <foreach collection="changeTrackingColumns" item="element" index="index"  open = "" separator=" OR" >
-            <bind name="__delta__" value="null" />
-            <bind name="__null_value__" value="null" />
-            <if test="changeTrackingColumnMaxDeltaValues != null">
-                <bind name="__delta__" value="changeTrackingColumnMaxDeltaValues[element]" />
-            </if>
-            <if test="changeTrackingColumnNullReplacements != null">
-                <bind name="__null_value__" value="changeTrackingColumnNullReplacements[element]" />
-            </if>
-            <choose>
-                <when test="__delta__ != null">
-                    abs(coalesce(me.${element},0) - coalesce(other.${element},0)) > ${__delta__}
-                </when>
-                <when test="__null_value__ != null">
-                    coalesce(me.${element},${__null_value__}) IS DISTINCT FROM coalesce(other.${element},${__null_value__})
-                </when>
-                <otherwise>
-                    me.${element} IS DISTINCT FROM other.${element}
-                </otherwise>
-            </choose>
-        </foreach>
-    </sql>
-
     <select id="mergeCardinalityCheck" resultType="Boolean" parameterType="String">
         SELECT EXISTS (
             SELECT COUNT(*) row_count

--- a/core/src/main/resources/dao/scd1_merge.xml
+++ b/core/src/main/resources/dao/scd1_merge.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="SCD1Merge">
-    <update id="mergeFindDiffs" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
+    <update id="changesBasedMergeFindDiffs" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
         COPY(
             WITH diffs AS (
             SELECT
                 CASE
                 <if test=" operationTypeColumn != null ">
-                    WHEN me.__candidate__ AND other.__candidate__ AND ${operationTypeColumn} = '${deleteOperationValue}' THEN 'D'
+                    WHEN me.__candidate__ AND other.__candidate__ AND ${operationTypeColumn} = ${deleteOperationValue} THEN 'D'
                 </if>
                     WHEN me.__candidate__ AND other.__candidate__ THEN 'U'
                     ELSE 'N'
@@ -27,7 +27,7 @@
         ) TO ${diffsFilePath} (FORMAT 'PARQUET', CODEC '${compression}', FILENAME_PATTERN "data_{uuid}", PARTITION_BY (__operation_type__))
     </update>
 
-    <update id="saveDistinctFileNames" parameterType="Map">
+    <update id="saveDistinctFileNamesForChangesMerge" parameterType="Map">
         COPY (
             SELECT DISTINCT filename
             FROM ${diffsFilePath}
@@ -39,7 +39,7 @@
         SELECT filename FROM '${value}'
     </select>
 
-    <update id="mergeUpserts" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
+    <update id="changesBasedMergeResults" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
         WITH updates AS (
             SELECT
             <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
@@ -47,7 +47,7 @@
             </foreach>
             FROM ${sourceTableName}
         <if test=" operationTypeColumn != null ">
-            WHERE ${operationTypeColumn} != '${deleteOperationValue}'
+            WHERE ${operationTypeColumn} != ${deleteOperationValue}
         </if>
             <if test="!appendOnly and diffsFilePath != null">
                 UNION ALL BY NAME
@@ -62,4 +62,105 @@
         SELECT * FROM updates
     </update>
 
+    <update id="snapshotBasedMergeAppendOnly" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
+        SELECT
+        <foreach collection="allColumns" item="element" index="index" open="" separator=",">
+            ${element}
+        </foreach>
+        FROM ${sourceTableName}
+    </update>
+
+    <update id="snapshotBasedMergeFindDiffs" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
+        COPY(
+            WITH diffs AS (
+                SELECT
+                <!--
+                    This CASE statement determines the operation type for each record by comparing source and target.
+                    Order of the below conditions is very important for correct operation detection.
+                -->
+                CASE
+                    <!-- Case 1: INSERT - If record exists in source but not in target (source is new) -->
+                    WHEN me.__candidate__ IS NULL THEN 'I'
+                    <!-- Case 2: UPDATE - If record exists in both source and target, but values differ -->
+                    WHEN me.__candidate__ AND other.__candidate__ AND (<include refid="valueColumnsDiff"/>) THEN 'U'
+                    <!-- Case 3: DELETE - If record exists in target but not in source (source is missing) -->
+                    WHEN me.__candidate__ AND other.__candidate__ IS NULL THEN 'D'
+                    <!-- Case 4: NO CHANGE - If record exists in both with matching values OR if records are outside the table filter boundary -->
+                    ELSE 'N'
+                END AS __operation_type__,
+                me.*,
+                <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
+                    other.${element} AS __other_${element}
+                </foreach>,
+                other.file_row_number AS __other_file_row_number__
+                FROM
+                (
+                    SELECT *, CASE WHEN ${boundaryCondition} THEN True ELSE False END AS __candidate__
+                    FROM ${destinationTableName}
+                ) me
+                FULL OUTER JOIN (
+                    SELECT *, True AS __candidate__ FROM ${sourceTableName}
+                ) other ON (me.__candidate__=other.__candidate__ AND <include refid="Common.keyColumnJoin"/> )
+            ),
+            diffs_modified AS (
+                SELECT * REPLACE(
+                    <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
+                        CASE WHEN __operation_type__='N' THEN NULL ELSE __other_${element} END AS __other_${element}
+                    </foreach>
+                )
+                FROM diffs
+            )
+            SELECT * FROM diffs_modified
+        ) TO ${diffsFilePath} (FORMAT 'PARQUET', CODEC '${compression}', FILENAME_PATTERN "data_{uuid}", PARTITION_BY (__operation_type__))
+    </update>
+
+    <update id="saveDistinctFileNamesForSnapshotMerge" parameterType="Map">
+        COPY (
+            SELECT DISTINCT filename
+            FROM ${diffsFilePath}
+            WHERE filename IS NOT NULL AND __operation_type__ NOT IN ('N')
+        ) TO '${modifiedFileNamesFilePath}' (FORMAT 'PARQUET', CODEC '${compression}')
+    </update>
+
+    <update id="snapshotBasedMergeResults" parameterType="com.arcesium.swiftlake.commands.SCD1MergeProperties">
+        SELECT
+            <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
+                __other_${element} AS ${element}
+            </foreach>,
+        FROM ${diffsFilePath}
+        WHERE __operation_type__ IN ('I', 'U')
+
+        UNION ALL BY NAME
+
+        SELECT
+            <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
+                ${element}
+            </foreach>
+        FROM ${diffsFilePath}
+        WHERE __operation_type__ = 'N' AND filename IN (SELECT filename FROM '${modifiedFileNamesFilePath}')
+    </update>
+
+    <sql id="valueColumnsDiff">
+        <foreach collection="valueColumns" item="element" index="index"  open = "" separator=" OR" >
+            <bind name="__delta__" value="null" />
+            <bind name="__null_value__" value="null" />
+            <if test="valueColumnMaxDeltaValues != null">
+                <bind name="__delta__" value="valueColumnMaxDeltaValues[element]" />
+            </if>
+            <if test="valueColumnNullReplacements != null">
+                <bind name="__null_value__" value="valueColumnNullReplacements[element]" />
+            </if>
+            <choose>
+                <when test="__delta__ != null">
+                    abs(coalesce(me.${element},0) - coalesce(other.${element},0)) > ${__delta__}
+                </when>
+                <when test="__null_value__ != null">
+                    coalesce(me.${element},${__null_value__}) IS DISTINCT FROM coalesce(other.${element},${__null_value__})
+                </when>
+                <otherwise>
+                    me.${element} IS DISTINCT FROM other.${element}
+                </otherwise>
+            </choose>
+        </foreach>
+    </sql>
 </mapper>

--- a/core/src/main/resources/dao/scd2_merge.xml
+++ b/core/src/main/resources/dao/scd2_merge.xml
@@ -18,7 +18,7 @@
                     <!-- if old record does not exist then insert -->
                     WHEN me.__candidate__ IS NULL THEN 'I'
                     <!-- if matching record found and values are different then update -->
-                    WHEN me.__candidate__ AND other.__candidate__ AND (<include refid="Common.changeTrackingColumnsDiff"/>) THEN 'U'
+                    WHEN me.__candidate__ AND other.__candidate__ AND (<include refid="changeTrackingColumnsDiff"/>) THEN 'U'
                     <!-- if old record exists but no matching new record then delete -->
                     WHEN me.__candidate__ AND other.__candidate__ IS NULL THEN 'D'
                     <!-- No change -->
@@ -28,7 +28,7 @@
                 <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
                     other.${element} AS __other_${element}
                 </foreach>,
-                other.file_row_number AS __other_file_row_number__,
+                other.file_row_number AS __other_file_row_number__
                 FROM
                 (
                     SELECT *, CASE WHEN ${boundaryCondition} AND ${effectiveStartColumn} &lt; ${effectiveTimestamp} AND ${effectiveEndColumn} IS NULL
@@ -43,8 +43,7 @@
                 SELECT * REPLACE(
                     <foreach collection="allColumns" item="element" index="index"  open = "" separator="," >
                         CASE WHEN __operation_type__='N' THEN NULL ELSE __other_${element} END AS __other_${element}
-                    </foreach>,
-                    CASE WHEN __operation_type__='N' THEN NULL ELSE __other_file_row_number__ END AS __other_file_row_number__
+                    </foreach>
                 )
                 FROM diffs
             )
@@ -141,10 +140,10 @@
                 CASE
                 <!-- Order of the below conditions is very important -->
                     <!-- Soft delete the matching record for delete operation value -->
-                    WHEN me.__candidate__ AND other.__candidate__ AND ${operationTypeColumn} = '${deleteOperationValue}' THEN 'D'
+                    WHEN me.__candidate__ AND other.__candidate__ AND ${operationTypeColumn} = ${deleteOperationValue} THEN 'D'
                     WHEN me.__candidate__ AND other.__candidate__ THEN
                     <!-- if matching record found and values are different, then update -->
-                        CASE WHEN (<include refid="Common.changeTrackingColumnsDiff"/>) THEN 'U' ELSE 'N-S' END
+                        CASE WHEN (<include refid="changeTrackingColumnsDiff"/>) THEN 'U' ELSE 'N-S' END
                     ELSE 'N'
                 END AS __operation_type__,
             me.*,
@@ -177,7 +176,7 @@
             SELECT *
             FROM (
                 SELECT src.*
-                FROM (SELECT * FROM ${sourceTableName} WHERE ${operationTypeColumn} != '${deleteOperationValue}') src
+                FROM (SELECT * FROM ${sourceTableName} WHERE ${operationTypeColumn} != ${deleteOperationValue}) src
                 <if test="!appendOnly and diffsFilePath != null">
                     LEFT OUTER JOIN (SELECT * FROM ${diffsFilePath} WHERE __operation_type__='N-S') nuDiffs
                         ON (<include refid="Common.keyColumnJoinWithAlias"><property name="leftAlias" value="src"/><property name="rightAlias" value="nuDiffs"/></include>)
@@ -222,4 +221,28 @@
         )
         SELECT * FROM updates
     </update>
+
+    <sql id="changeTrackingColumnsDiff">
+        <foreach collection="changeTrackingColumns" item="element" index="index"  open = "" separator=" OR" >
+            <bind name="__delta__" value="null" />
+            <bind name="__null_value__" value="null" />
+            <if test="changeTrackingColumnMaxDeltaValues != null">
+                <bind name="__delta__" value="changeTrackingColumnMaxDeltaValues[element]" />
+            </if>
+            <if test="changeTrackingColumnNullReplacements != null">
+                <bind name="__null_value__" value="changeTrackingColumnNullReplacements[element]" />
+            </if>
+            <choose>
+                <when test="__delta__ != null">
+                    abs(coalesce(me.${element},0) - coalesce(other.${element},0)) > ${__delta__}
+                </when>
+                <when test="__null_value__ != null">
+                    coalesce(me.${element},${__null_value__}) IS DISTINCT FROM coalesce(other.${element},${__null_value__})
+                </when>
+                <otherwise>
+                    me.${element} IS DISTINCT FROM other.${element}
+                </otherwise>
+            </choose>
+        </foreach>
+    </sql>
 </mapper>

--- a/core/src/test/java/com/arcesium/swiftlake/commands/SCD1MergeBasicIntegrationTest.java
+++ b/core/src/test/java/com/arcesium/swiftlake/commands/SCD1MergeBasicIntegrationTest.java
@@ -22,6 +22,7 @@ import com.arcesium.swiftlake.SwiftLakeEngine;
 import com.arcesium.swiftlake.TestUtil;
 import com.arcesium.swiftlake.common.ValidationException;
 import com.arcesium.swiftlake.expressions.Expressions;
+import com.arcesium.swiftlake.metrics.CommitMetrics;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -34,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,17 +114,54 @@ public class SCD1MergeBasicIntegrationTest {
         schema = swiftLakeEngine.getTable(tableName).schema();
       }
       SCD1MergeInput mergeInput = mergeInputList.get(i);
-      String sourceSql = TestUtil.createChangeSql(mergeInput.inputData, schema);
-      Runnable mergeFunc =
-          () ->
-              swiftLakeEngine
-                  .applyChangesAsSCD1(tableName)
-                  .tableFilterSql(mergeInput.tableFilter)
-                  .sourceSql(sourceSql)
-                  .keyColumns(mergeInput.keyColumns)
-                  .operationTypeColumn("operation_type", "D")
-                  .processSourceTables(false)
-                  .execute();
+
+      Runnable mergeFunc;
+      if (mergeInput.isSnapshot) {
+        // Snapshot mode
+        String sourceSql = TestUtil.createSelectSql(mergeInput.inputData, schema);
+        mergeFunc =
+            () -> {
+              var builder =
+                  swiftLakeEngine
+                      .applySnapshotAsSCD1(tableName)
+                      .tableFilterSql(mergeInput.tableFilter)
+                      .sourceSql(sourceSql)
+                      .keyColumns(mergeInput.keyColumns)
+                      .processSourceTables(false);
+
+              // Apply optional parameters
+              if (mergeInput.valueColumns != null) {
+                builder.valueColumns(mergeInput.valueColumns);
+              }
+
+              if (mergeInput.valueColumnMetadata != null) {
+                mergeInput.valueColumnMetadata.forEach(
+                    (column, metadata) -> builder.valueColumnMetadata(column, metadata));
+              }
+
+              if (mergeInput.skipEmptySource != null) {
+                builder.skipEmptySource(mergeInput.skipEmptySource);
+              }
+
+              builder.execute();
+            };
+      } else {
+        // Changes mode
+        String changeSql =
+            TestUtil.createChangeSql(mergeInput.inputData, schema, mergeInput.operationTypeColumn);
+        mergeFunc =
+            () ->
+                swiftLakeEngine
+                    .applyChangesAsSCD1(tableName)
+                    .tableFilterSql(mergeInput.tableFilter)
+                    .sourceSql(changeSql)
+                    .keyColumns(mergeInput.keyColumns)
+                    .operationTypeColumn(
+                        mergeInput.operationTypeColumn, mergeInput.deleteOperationValue)
+                    .processSourceTables(false)
+                    .execute();
+      }
+
       if (errors != null && errors.size() > i) {
         var throwableAssert = assertThatThrownBy(() -> mergeFunc.run());
         var error = errors.get(i);
@@ -146,25 +185,50 @@ public class SCD1MergeBasicIntegrationTest {
   }
 
   private static Stream<Arguments> provideTestCases() {
-    return Stream.of(
-        simpleSchemaTestCase(),
-        complexTypesTestCase(),
-        noChangesTestCase(),
-        allInsertsTestCase(),
-        allDeletesTestCase(),
-        emptySourceTestCase(),
-        multipleOperationsTestCase(),
-        nullValuesTestCase(),
-        longHistoryChainTestCase(),
-        extremeValuesTestCase(),
-        unicodeAndSpecialCharactersTestCase(),
-        timeZoneHandlingTestCase(),
-        schemaEvolutionTestCase(),
-        multiColumnKeyTestCase(),
-        errorHandlingTestCase());
+    return Stream.concat(
+        Stream.of(
+            simpleSchemaTestCase(false),
+            simpleSchemaTestCase(true),
+            complexTypesTestCase(false),
+            complexTypesTestCase(true),
+            noChangesTestCase(false),
+            noChangesTestCase(true),
+            allInsertsTestCase(false),
+            allInsertsTestCase(true),
+            allDeletesTestCase(false),
+            allDeletesTestCase(true),
+            emptySourceTestCase(false),
+            emptySourceTestCase(true),
+            multipleOperationsTestCase(false),
+            multipleOperationsTestCase(true),
+            nullValuesTestCase(false),
+            nullValuesTestCase(true),
+            replaceAllTestCase(false),
+            replaceAllTestCase(true),
+            partialMergeWithFiltersTestCase(false),
+            partialMergeWithFiltersTestCase(true),
+            longHistoryChainTestCase(false),
+            longHistoryChainTestCase(true),
+            extremeValuesTestCase(false),
+            extremeValuesTestCase(true),
+            unicodeAndSpecialCharactersTestCase(false),
+            unicodeAndSpecialCharactersTestCase(true),
+            timeZoneHandlingTestCase(false),
+            timeZoneHandlingTestCase(true),
+            schemaEvolutionTestCase(false),
+            schemaEvolutionTestCase(true),
+            multiColumnKeyTestCase(false),
+            multiColumnKeyTestCase(true),
+            errorHandlingTestCase(false),
+            errorHandlingTestCase(true),
+            valueColumnsTestCase(),
+            valueColumnsWithMaxDeltaTestCase(),
+            valueColumnsWithNullReplacementTestCase(),
+            skipEmptySourceTestCase()),
+        provideOperationTypeValidationTestCases());
   }
 
-  private static Arguments simpleSchemaTestCase() {
+  private static Arguments simpleSchemaTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -174,12 +238,20 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
 
-    List<Map<String, Object>> inputData = null;
+    List<Map<String, Object>> inputData;
 
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John Doe", "operation_type", "U"),
-            Map.of("id", 3L, "name", "Bob", "operation_type", "I"));
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe"),
+              Map.of("id", 2L, "name", "Jane"),
+              Map.of("id", 3L, "name", "Bob"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "operation_type", "U"),
+              Map.of("id", 3L, "name", "Bob", "operation_type", "I"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
@@ -189,9 +261,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "simple_schema",
+        "simple_schema" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -201,7 +274,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments complexTypesTestCase() {
+  private static Arguments complexTypesTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -229,11 +302,19 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(createComplexRow(1L, "2025-01-01"), createComplexRow(2L, "2025-01-01"));
 
-    List<Map<String, Object>> inputData = null;
+    List<Map<String, Object>> inputData;
 
-    inputData =
-        Arrays.asList(
-            updateComplexRow(1L, "2025-01-01", "U"), createComplexRow(3L, "2025-01-01", "I"));
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              updateComplexRow(1L, "2025-01-01", null),
+              createComplexRow(2L, "2025-01-01"),
+              createComplexRow(3L, "2025-01-01"));
+    } else {
+      inputData =
+          Arrays.asList(
+              updateComplexRow(1L, "2025-01-01", "U"), createComplexRow(3L, "2025-01-01", "I"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
@@ -243,9 +324,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "complex_types",
+        "complex_types" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -255,7 +337,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments noChangesTestCase() {
+  private static Arguments noChangesTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -265,21 +347,26 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
 
-    List<Map<String, Object>> inputData = null;
+    List<Map<String, Object>> inputData;
 
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John", "operation_type", "U"),
-            Map.of("id", 2L, "name", "Jane", "operation_type", "U"));
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John", "operation_type", "U"),
+              Map.of("id", 2L, "name", "Jane", "operation_type", "U"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "no_changes",
+        "no_changes" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -289,7 +376,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments allInsertsTestCase() {
+  private static Arguments allInsertsTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -298,12 +385,22 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<Map<String, Object>> initialData = new ArrayList<>();
 
-    List<Map<String, Object>> inputData = null;
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John", "operation_type", "I"),
-            Map.of("id", 2L, "name", "Jane", "operation_type", "I"),
-            Map.of("id", 3L, "name", "Bob", "operation_type", "I"));
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John"),
+              Map.of("id", 2L, "name", "Jane"),
+              Map.of("id", 3L, "name", "Bob"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John", "operation_type", "I"),
+              Map.of("id", 2L, "name", "Jane", "operation_type", "I"),
+              Map.of("id", 3L, "name", "Bob", "operation_type", "I"));
+    }
+
     List<Map<String, Object>> expectedData =
         Arrays.asList(
             Map.of("id", 1L, "name", "John"),
@@ -312,9 +409,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "all_inserts",
+        "all_inserts" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -324,7 +422,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments allDeletesTestCase() {
+  private static Arguments allDeletesTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -337,19 +435,28 @@ public class SCD1MergeBasicIntegrationTest {
             Map.of("id", 2L, "name", "Jane"),
             Map.of("id", 3L, "name", "Bob"));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John", "operation_type", "D"),
-            Map.of("id", 2L, "name", "Jane", "operation_type", "D"),
-            Map.of("id", 3L, "name", "Bob", "operation_type", "D"));
+    List<Map<String, Object>> inputData;
 
+    if (isSnapshotMode) {
+      // Empty snapshot - will delete all records matching the filter
+      inputData = new ArrayList<>();
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John", "operation_type", "D"),
+              Map.of("id", 2L, "name", "Jane", "operation_type", "D"),
+              Map.of("id", 3L, "name", "Bob", "operation_type", "D"));
+    }
+
+    // Empty result - all records deleted
     List<Map<String, Object>> expectedData = Arrays.asList();
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "all_deletes",
+        "all_deletes" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -359,7 +466,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments emptySourceTestCase() {
+  private static Arguments emptySourceTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -369,16 +476,26 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
 
+    // Empty input data
     List<Map<String, Object>> inputData = new ArrayList<>();
 
-    List<Map<String, Object>> expectedData =
-        Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
+    List<Map<String, Object>> expectedData;
+
+    if (isSnapshotMode) {
+      // In snapshot mode, empty source means delete all records that match the filter
+      expectedData = new ArrayList<>();
+    } else {
+      // In changes mode, empty source means no changes
+      expectedData =
+          Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
+    }
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "empty_source",
+        "empty_source" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -388,7 +505,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments multipleOperationsTestCase() {
+  private static Arguments multipleOperationsTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -398,21 +515,41 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "name", "John"), Map.of("id", 2L, "name", "Jane"));
 
-    List<List<Map<String, Object>>> inputDataList = null;
+    List<List<Map<String, Object>>> inputDataList;
 
-    inputDataList =
-        Arrays.asList(
-            Arrays.asList(
-                Map.of("id", 1L, "name", "John Doe", "operation_type", "U"),
-                Map.of("id", 3L, "name", "Bob", "operation_type", "I")),
-            Arrays.asList(
-                Map.of("id", 2L, "name", "Jane Doe", "operation_type", "U"),
-                Map.of("id", 1L, "name", "John", "operation_type", "D"),
-                Map.of("id", 5L, "name", "Jane Doe", "operation_type", "I")),
-            Arrays.asList(
-                Map.of("id", 2L, "name", "Jane Doe", "operation_type", "D"),
-                Map.of("id", 4L, "name", "Alice", "operation_type", "I"),
-                Map.of("id", 3L, "name", "Robert", "operation_type", "U")));
+    if (isSnapshotMode) {
+      inputDataList =
+          Arrays.asList(
+              // First snapshot
+              Arrays.asList(
+                  Map.of("id", 1L, "name", "John Doe"),
+                  Map.of("id", 2L, "name", "Jane"),
+                  Map.of("id", 3L, "name", "Bob")),
+              // Second snapshot
+              Arrays.asList(
+                  Map.of("id", 2L, "name", "Jane Doe"),
+                  Map.of("id", 3L, "name", "Bob"),
+                  Map.of("id", 5L, "name", "Jane Doe")),
+              // Third snapshot
+              Arrays.asList(
+                  Map.of("id", 3L, "name", "Robert"),
+                  Map.of("id", 4L, "name", "Alice"),
+                  Map.of("id", 5L, "name", "Jane Doe")));
+    } else {
+      inputDataList =
+          Arrays.asList(
+              Arrays.asList(
+                  Map.of("id", 1L, "name", "John Doe", "operation_type", "U"),
+                  Map.of("id", 3L, "name", "Bob", "operation_type", "I")),
+              Arrays.asList(
+                  Map.of("id", 2L, "name", "Jane Doe", "operation_type", "U"),
+                  Map.of("id", 1L, "name", "John", "operation_type", "D"),
+                  Map.of("id", 5L, "name", "Jane Doe", "operation_type", "I")),
+              Arrays.asList(
+                  Map.of("id", 2L, "name", "Jane Doe", "operation_type", "D"),
+                  Map.of("id", 4L, "name", "Alice", "operation_type", "I"),
+                  Map.of("id", 3L, "name", "Robert", "operation_type", "U")));
+    }
     List<Map<String, Object>> expectedData =
         Arrays.asList(
             Map.of("id", 3L, "name", "Robert"),
@@ -423,11 +560,12 @@ public class SCD1MergeBasicIntegrationTest {
     String tableFilter = "id IS NOT NULL";
     List<SCD1MergeInput> mergeInputs =
         inputDataList.stream()
-            .map(inputData -> new SCD1MergeInput(inputData, tableFilter, keyColumns))
+            .map(
+                inputData -> new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode))
             .collect(Collectors.toList());
 
     return Arguments.of(
-        "multiple_operations",
+        "multiple_operations" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -437,7 +575,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments longHistoryChainTestCase() {
+  private static Arguments longHistoryChainTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
@@ -625,11 +763,12 @@ public class SCD1MergeBasicIntegrationTest {
     String tableFilter = "id IS NOT NULL";
     List<SCD1MergeInput> mergeInputs =
         inputDataList.stream()
-            .map(inputData -> new SCD1MergeInput(inputData, tableFilter, keyColumns))
+            .map(
+                inputData -> new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode))
             .collect(Collectors.toList());
 
     return Arguments.of(
-        "long_history_chain",
+        "long_history_chain" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -680,7 +819,7 @@ public class SCD1MergeBasicIntegrationTest {
     return row;
   }
 
-  private static Arguments nullValuesTestCase() {
+  private static Arguments nullValuesTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -691,24 +830,45 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "nullable_string", "value", "nullable_int", 10));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(
-            new HashMap<>() {
-              {
-                put("id", 1L);
-                put("nullable_string", null);
-                put("nullable_int", null);
-                put("operation_type", "U");
-              }
-            },
-            new HashMap<>() {
-              {
-                put("id", 2L);
-                put("nullable_string", "new");
-                put("nullable_int", null);
-                put("operation_type", "I");
-              }
-            });
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              new HashMap<>() {
+                {
+                  put("id", 1L);
+                  put("nullable_string", null);
+                  put("nullable_int", null);
+                }
+              },
+              new HashMap<>() {
+                {
+                  put("id", 2L);
+                  put("nullable_string", "new");
+                  put("nullable_int", null);
+                }
+              });
+    } else {
+      inputData =
+          Arrays.asList(
+              new HashMap<>() {
+                {
+                  put("id", 1L);
+                  put("nullable_string", null);
+                  put("nullable_int", null);
+                  put("operation_type", "U");
+                }
+              },
+              new HashMap<>() {
+                {
+                  put("id", 2L);
+                  put("nullable_string", "new");
+                  put("nullable_int", null);
+                  put("operation_type", "I");
+                }
+              });
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
@@ -729,9 +889,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "null_values",
+        "null_values" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -741,7 +902,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments extremeValuesTestCase() {
+  private static Arguments extremeValuesTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -755,26 +916,38 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "long_string", "initial", "big_number", BigDecimal.ONE));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(
-            Map.of(
-                "id",
-                1L,
-                "long_string",
-                longString,
-                "big_number",
-                bigNumber,
-                "operation_type",
-                "U"));
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of(
+                  "id", 1L,
+                  "long_string", longString,
+                  "big_number", bigNumber));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of(
+                  "id",
+                  1L,
+                  "long_string",
+                  longString,
+                  "big_number",
+                  bigNumber,
+                  "operation_type",
+                  "U"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(Map.of("id", 1L, "long_string", longString, "big_number", bigNumber));
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "extreme_values",
+        "extreme_values" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -784,7 +957,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments unicodeAndSpecialCharactersTestCase() {
+  private static Arguments unicodeAndSpecialCharactersTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -796,17 +969,24 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "special_string", "normal"));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(Map.of("id", 1L, "special_string", specialString, "operation_type", "U"));
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1L, "special_string", specialString));
+    } else {
+      inputData =
+          Arrays.asList(Map.of("id", 1L, "special_string", specialString, "operation_type", "U"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(Map.of("id", 1L, "special_string", specialString));
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "special_characters",
+        "special_characters" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -816,7 +996,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments timeZoneHandlingTestCase() {
+  private static Arguments timeZoneHandlingTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -830,8 +1010,14 @@ public class SCD1MergeBasicIntegrationTest {
     List<Map<String, Object>> initialData =
         Arrays.asList(Map.of("id", 1L, "timestamp_with_tz", utcTime));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(Map.of("id", 1L, "timestamp_with_tz", changedTime, "operation_type", "U"));
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1L, "timestamp_with_tz", changedTime));
+    } else {
+      inputData =
+          Arrays.asList(Map.of("id", 1L, "timestamp_with_tz", changedTime, "operation_type", "U"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
@@ -840,9 +1026,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "time_zone_handling",
+        "time_zone_handling" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -852,7 +1039,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments schemaEvolutionTestCase() {
+  private static Arguments schemaEvolutionTestCase(boolean isSnapshotMode) {
     Schema initialSchema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -867,18 +1054,23 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<Map<String, Object>> initialData = Arrays.asList(Map.of("id", 1L, "name", "John"));
 
-    List<Map<String, Object>> inputData =
-        Arrays.asList(
-            Map.of(
-                "id",
-                1L,
-                "name",
-                "John Doe",
-                "email",
-                "john.doe@example.com",
-                "operation_type",
-                "U"),
-            Map.of("id", 2L, "name", "Jane", "email", "jane@example.com", "operation_type", "I"));
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "email", "john.doe@example.com"),
+              Map.of("id", 2L, "name", "Jane", "email", "jane@example.com"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of(
+                  "id", 1L,
+                  "name", "John Doe",
+                  "email", "john.doe@example.com",
+                  "operation_type", "U"),
+              Map.of("id", 2L, "name", "Jane", "email", "jane@example.com", "operation_type", "I"));
+    }
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
@@ -887,9 +1079,10 @@ public class SCD1MergeBasicIntegrationTest {
 
     List<String> keyColumns = Arrays.asList("id");
     String tableFilter = "id IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "schema_evolution",
+        "schema_evolution" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         initialSchema,
         partitionSpec,
         initialData,
@@ -899,7 +1092,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments multiColumnKeyTestCase() {
+  private static Arguments multiColumnKeyTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id1", Types.LongType.get()),
@@ -913,23 +1106,45 @@ public class SCD1MergeBasicIntegrationTest {
             Map.of("id1", 1L, "id2", "B", "value", "Initial2"),
             Map.of("id1", 2L, "id2", "A", "value", "Initial3"));
 
-    List<Map<String, Object>> inputData = null;
-    inputData =
-        Arrays.asList(
-            Map.of("id1", 1L, "id2", "A", "value", "Updated1", "operation_type", "U"),
-            Map.of("id1", 2L, "id2", "B", "value", "New", "operation_type", "I"),
-            Map.of("id1", 2L, "id2", "A", "value", "ToDelete", "operation_type", "D"));
-    List<Map<String, Object>> expectedData =
-        Arrays.asList(
-            Map.of("id1", 1L, "id2", "B", "value", "Initial2"),
-            Map.of("id1", 1L, "id2", "A", "value", "Updated1"),
-            Map.of("id1", 2L, "id2", "B", "value", "New"));
+    List<Map<String, Object>> inputData;
+    List<Map<String, Object>> expectedData;
+
+    if (isSnapshotMode) {
+      // In snapshot mode, records in the target table are kept if they match the filter and their
+      // key is in the snapshot
+      inputData =
+          Arrays.asList(
+              Map.of("id1", 1L, "id2", "A", "value", "Updated1"),
+              Map.of("id1", 1L, "id2", "B", "value", "Initial2"), // keep this one unchanged
+              Map.of("id1", 2L, "id2", "B", "value", "New")); // new record
+
+      expectedData =
+          Arrays.asList(
+              Map.of("id1", 1L, "id2", "A", "value", "Updated1"),
+              Map.of("id1", 1L, "id2", "B", "value", "Initial2"),
+              Map.of("id1", 2L, "id2", "B", "value", "New"));
+
+      // Note: id1=2, id2=A will be deleted because it's not in the snapshot
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id1", 1L, "id2", "A", "value", "Updated1", "operation_type", "U"),
+              Map.of("id1", 2L, "id2", "B", "value", "New", "operation_type", "I"),
+              Map.of("id1", 2L, "id2", "A", "value", "ToDelete", "operation_type", "D"));
+
+      expectedData =
+          Arrays.asList(
+              Map.of("id1", 1L, "id2", "A", "value", "Updated1"),
+              Map.of("id1", 1L, "id2", "B", "value", "Initial2"),
+              Map.of("id1", 2L, "id2", "B", "value", "New"));
+    }
 
     List<String> keyColumns = Arrays.asList("id1", "id2");
     String tableFilter = "id1 IS NOT NULL";
-    SCD1MergeInput mergeInput = new SCD1MergeInput(inputData, tableFilter, keyColumns);
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
     return Arguments.of(
-        "multi_column_key",
+        "multi_column_key" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -939,7 +1154,7 @@ public class SCD1MergeBasicIntegrationTest {
         null);
   }
 
-  private static Arguments errorHandlingTestCase() {
+  private static Arguments errorHandlingTestCase(boolean isSnapshotMode) {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -959,56 +1174,294 @@ public class SCD1MergeBasicIntegrationTest {
     String tableFilter = "id IS NOT NULL";
 
     // Missing required columns
-    List<Map<String, Object>> inputData = null;
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "value", 300.0, "operation_type", "U"),
-            Map.of("id", 2L, "operation_type", "I"));
-    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns));
+    List<Map<String, Object>> inputData;
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1L, "value", 300.0), Map.of("id", 2L));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "value", 300.0, "operation_type", "U"),
+              Map.of("id", 2L, "operation_type", "I"));
+    }
+
+    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
     errors.add(
         Pair.of(
             ValidationException.class, "Required fields cannot contain null values - name,value"));
 
     // Null value for required columns
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
-            new HashMap<String, Object>() {
-              {
-                put("id", 3L);
-                put("name", "Bob");
-                put("value", null);
-                put("operation_type", "I");
-              }
-            });
-    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns));
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0),
+              new HashMap<String, Object>() {
+                {
+                  put("id", 3L);
+                  put("name", "Bob");
+                  put("value", null);
+                }
+              });
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
+              new HashMap<String, Object>() {
+                {
+                  put("id", 3L);
+                  put("name", "Bob");
+                  put("value", null);
+                  put("operation_type", "I");
+                }
+              });
+    }
+
+    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
     errors.add(
         Pair.of(ValidationException.class, "Required fields cannot contain null values - value"));
 
     // Duplicate records
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
-            Map.of("id", 1L, "name", "Bob", "value", 400.0, "operation_type", "D"));
-    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns));
-    errors.add(
-        Pair.of(
-            ValidationException.class,
-            "Merge operation matched a single row from target table data with multiple rows of the source data"));
-    inputData =
-        Arrays.asList(
-            Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
-            Map.of("id", 3L, "name", "Bob", "value", 400.0, "operation_type", "I"));
-    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns));
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0),
+              Map.of("id", 1L, "name", "Bob", "value", 400.0));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
+              Map.of("id", 1L, "name", "Bob", "value", 400.0, "operation_type", "D"));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    }
+
+    // More duplicate cases
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 2L, "name", "Jane", "value", 200.0),
+              Map.of("id", 2L, "name", "Jane", "value", 200.0));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    } else {
+      // Duplicate records - same operation type
+      inputData =
+          Arrays.asList(
+              Map.of("id", 2L, "name", "Jane", "value", 200.0, "operation_type", "U"),
+              Map.of("id", 2L, "name", "Jane", "value", 200.0, "operation_type", "D"));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    }
+
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 2L, "name", "Jane", "value", 200.0),
+              Map.of("id", 2L, "name", "Jane", "value", 200.0));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    } else {
+      // Duplicate records - same operation type
+      inputData =
+          Arrays.asList(
+              Map.of("id", 2L, "name", "Jane", "value", 200.0, "operation_type", "U"),
+              Map.of("id", 2L, "name", "Jane", "value", 200.0, "operation_type", "U"));
+
+      mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Merge operation matched a single row from target table data with multiple rows of the source data"));
+    }
+
+    // Null key columns
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+    } else {
+      inputData =
+          Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0, "operation_type", "U"));
+    }
+    mergeInputs.add(
+        new SCD1MergeInput(inputData, "id = 1", null, isSnapshotMode, null, null, null));
+    errors.add(Pair.of(ValidationException.class, "Key columns cannot be null or empty"));
+
+    // Empty key columns
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+    } else {
+      inputData =
+          Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0, "operation_type", "U"));
+    }
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData,
+            "id = 1",
+            Collections.emptyList(), // empty key columns
+            isSnapshotMode,
+            null,
+            null,
+            null));
+    errors.add(Pair.of(ValidationException.class, "Key columns cannot be null or empty"));
+
+    // Key column not in schema
+    if (isSnapshotMode) {
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+    } else {
+      inputData =
+          Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0, "operation_type", "U"));
+    }
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData,
+            "id = 1",
+            Arrays.asList("id", "non_existent_column"), // invalid key column
+            isSnapshotMode,
+            null,
+            null,
+            null));
+    errors.add(Pair.of(ValidationException.class, "Invalid key column non_existent_column"));
+
+    // Table filter column not in schema
+    inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+    if (isSnapshotMode) {
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "non_existent_column = 1", // invalid filter column
+              Arrays.asList("id"),
+              isSnapshotMode,
+              null,
+              null,
+              null));
+      errors.add(Pair.of(ValidationException.class, "Column does not exist non_existent_column"));
+    } else {
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "non_existent_column = 1", // invalid filter column
+              Arrays.asList("id"),
+              isSnapshotMode,
+              null,
+              null,
+              null));
+      errors.add(Pair.of(ValidationException.class, "Column does not exist non_existent_column"));
+    }
+
+    if (isSnapshotMode) {
+      // Empty value columns list
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData, "id = 1", Arrays.asList("id"), true, Collections.emptyList(), null, null));
+      errors.add(Pair.of(ValidationException.class, "Value columns cannot be empty"));
+
+      // Value column not in schema
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "id = 1",
+              Arrays.asList("id"),
+              true,
+              Arrays.asList("name", "non_existent_column"),
+              null,
+              null));
+      errors.add(Pair.of(ValidationException.class, "Invalid value column non_existent_column"));
+
+      // Column cannot be both key and value
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "id = 1",
+              Arrays.asList("id"),
+              true,
+              Arrays.asList("id", "value"),
+              null,
+              null));
+      errors.add(
+          Pair.of(ValidationException.class, "cannot be both a key column and a value column"));
+
+      // Value column metadata for non-value column
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+      Map<String, ValueColumnMetadata<?>> valueMetadata4 = new HashMap<>();
+      valueMetadata4.put("value", new ValueColumnMetadata<>(0.1, null));
+      valueMetadata4.put("non_value_column", new ValueColumnMetadata<>(0.5, null));
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "id = 1",
+              Arrays.asList("id"),
+              true,
+              Arrays.asList("name", "value"),
+              valueMetadata4,
+              null));
+      errors.add(Pair.of(ValidationException.class, "Invalid value column non_value_column"));
+
+      // Cannot specify both max delta and null value
+      inputData = Arrays.asList(Map.of("id", 1, "name", "John", "value", 101.0));
+      Map<String, ValueColumnMetadata<?>> valueMetadata5 = new HashMap<>();
+      valueMetadata5.put("value", new ValueColumnMetadata<>(0.1, 0.0));
+      mergeInputs.add(
+          new SCD1MergeInput(
+              inputData,
+              "id = 1",
+              Arrays.asList("id"),
+              true,
+              Arrays.asList("name", "value"),
+              valueMetadata5,
+              null));
+      errors.add(
+          Pair.of(
+              ValidationException.class,
+              "Provide either max delta value or null value for the value column"));
+    }
+
+    // Final valid input
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0),
+              Map.of("id", 2L, "name", "Jane", "value", 200.0),
+              Map.of("id", 3L, "name", "Bob", "value", 400.0));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "name", "John Doe", "value", 300.0, "operation_type", "U"),
+              Map.of("id", 3L, "name", "Bob", "value", 400.0, "operation_type", "I"));
+    }
+
+    mergeInputs.add(new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode));
 
     List<Map<String, Object>> expectedData =
         Arrays.asList(
-            Map.of("id", 2L, "name", "Jane", "value", 200.0),
             Map.of("id", 1L, "name", "John Doe", "value", 300.0),
+            Map.of("id", 2L, "name", "Jane", "value", 200.0),
             Map.of("id", 3L, "name", "Bob", "value", 400.0));
 
     return Arguments.of(
-        "error_handling",
+        "error_handling" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
         schema,
         partitionSpec,
         initialData,
@@ -1018,10 +1471,501 @@ public class SCD1MergeBasicIntegrationTest {
         errors);
   }
 
+  private static Stream<Arguments> provideOperationTypeValidationTestCases() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.required(3, "value", Types.DoubleType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    // Common initial data for all tests
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John", "value", 100.0),
+            Map.of("id", 2L, "name", "Jane", "value", 200.0));
+
+    return Stream.of(
+        // Delete value provided without operation type column
+        Arguments.of(
+            "missing_op_type_column",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    null, // Null operation column
+                    "D" // But has delete value
+                    )),
+            initialData, // No change expected since it errors
+            null,
+            Collections.singletonList(
+                Pair.of(
+                    ValidationException.class,
+                    "Operation type column must be specified when delete operation value is provided"))),
+
+        // Empty operation type column
+        Arguments.of(
+            "empty_op_type_column",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "", // Empty operation column
+                    "D")),
+            initialData, // No change expected since it errors
+            null,
+            Collections.singletonList(
+                Pair.of(ValidationException.class, "Operation type column cannot be empty"))),
+
+        // Missing delete operation value
+        Arguments.of(
+            "missing_delete_value",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of("id", 1L, "name", "John Updated", "value", 101.0, "op_type", "U")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op_type",
+                    null // Null delete value
+                    )),
+            initialData, // No change expected since it errors
+            null,
+            Collections.singletonList(
+                Pair.of(ValidationException.class, "Delete operation value is mandatory"))),
+
+        // Empty delete operation value
+        Arguments.of(
+            "empty_delete_value",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of("id", 1L, "name", "John Updated", "value", 101.0, "op_type", "U")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op_type",
+                    "" // Empty delete value
+                    )),
+            initialData, // No change expected since it errors
+            null,
+            Collections.singletonList(
+                Pair.of(ValidationException.class, "Delete operation value is mandatory"))),
+
+        // Operation type column with spaces - successful case with update and delete
+        Arguments.of(
+            "op_col_with_spaces",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "op type with spaces",
+                            "U"),
+                        Map.of(
+                            "id", 2L, "name", "Jane", "value", 200.0, "op type with spaces", "D")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op type with spaces",
+                    "D")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Operation type column with double quotes
+        Arguments.of(
+            "op_col_with_double_quotes",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 1L);
+                            put("name", "John Updated");
+                            put("value", 101.0);
+                            put("op\"quote", "U");
+                          }
+                        },
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 2L);
+                            put("name", "Jane");
+                            put("value", 200.0);
+                            put("op\"quote", "D");
+                          }
+                        }),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op\"quote",
+                    "D")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Operation type column with single quotes
+        Arguments.of(
+            "op_col_with_single_quotes",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 1L);
+                            put("name", "John Updated");
+                            put("value", 101.0);
+                            put("op'quote", "U");
+                          }
+                        },
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 2L);
+                            put("name", null);
+                            put("value", null);
+                            put("op'quote", "D");
+                          }
+                        }),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op'quote",
+                    "D")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Operation type column with special characters
+        Arguments.of(
+            "op_col_with_special_chars",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 1L);
+                            put("name", "John Updated");
+                            put("value", 101.0);
+                            put("op!@#$%", "U");
+                          }
+                        },
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 2L);
+                            put("name", null);
+                            put("value", null);
+                            put("op!@#$%", "D");
+                          }
+                        }),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op!@#$%",
+                    "D")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Operation type column with control characters
+        Arguments.of(
+            "op_col_with_control_chars",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 1L);
+                            put("name", "John Updated");
+                            put("value", 101.0);
+                            put("op\t\n\r", "U");
+                          }
+                        },
+                        new HashMap<String, Object>() {
+                          {
+                            put("id", 2L);
+                            put("name", null);
+                            put("value", null);
+                            put("op\t\n\r", "D");
+                          }
+                        }),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "op\t\n\r",
+                    "D")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Delete value with special characters
+        Arguments.of(
+            "delete_value_with_special_chars",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "operation_type",
+                            "U"),
+                        Map.of(
+                            "id",
+                            2L,
+                            "name",
+                            "Jane",
+                            "value",
+                            200.0,
+                            "operation_type",
+                            "D!@#$%^&*()")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "operation_type",
+                    "D!@#$%^&*()")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Delete value with double quotes
+        Arguments.of(
+            "delete_value_with_double_quotes",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "operation_type",
+                            "U"),
+                        Map.of(
+                            "id",
+                            2L,
+                            "name",
+                            "Jane",
+                            "value",
+                            200.0,
+                            "operation_type",
+                            "D\"delete\"")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "operation_type",
+                    "D\"delete\"")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Delete value with single quotes
+        Arguments.of(
+            "delete_value_with_single_quotes",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "operation_type",
+                            "U"),
+                        Map.of(
+                            "id",
+                            2L,
+                            "name",
+                            "Jane",
+                            "value",
+                            200.0,
+                            "operation_type",
+                            "D'delete'")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "operation_type",
+                    "D'delete'")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Delete value with spaces
+        Arguments.of(
+            "delete_value_with_spaces",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "operation_type",
+                            "U"),
+                        Map.of(
+                            "id",
+                            2L,
+                            "name",
+                            "Jane",
+                            "value",
+                            200.0,
+                            "operation_type",
+                            " D delete ")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "operation_type",
+                    " D delete ")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ),
+
+        // Delete value with control characters
+        Arguments.of(
+            "delete_value_with_control_chars",
+            schema,
+            partitionSpec,
+            initialData,
+            Collections.singletonList(
+                new SCD1MergeInput(
+                    Arrays.asList(
+                        Map.of(
+                            "id",
+                            1L,
+                            "name",
+                            "John Updated",
+                            "value",
+                            101.0,
+                            "operation_type",
+                            "U"),
+                        Map.of(
+                            "id", 2L, "name", "Jane", "value", 200.0, "operation_type", "D\t\n\r")),
+                    "id IS NOT NULL",
+                    Arrays.asList("id"),
+                    false,
+                    null,
+                    null,
+                    null,
+                    "operation_type",
+                    "D\t\n\r")),
+            Arrays.asList(Map.of("id", 1L, "name", "John Updated", "value", 101.0)),
+            null,
+            null // No validation errors
+            ));
+  }
+
   @ParameterizedTest
   @MethodSource("providePartitionStrategies")
   void testDifferentPartitionStrategies(
-      PartitionSpec partitionSpec, List<Pair<String, Long>> partitionLevelRecordCounts) {
+      PartitionSpec partitionSpec,
+      List<Pair<String, Long>> partitionLevelRecordCounts,
+      boolean isSnapshotMode) {
     Schema schema = getSchemaForPartitionStrategiesTest();
 
     TableIdentifier tableId =
@@ -1059,39 +2003,83 @@ public class SCD1MergeBasicIntegrationTest {
         .execute();
 
     List<Map<String, Object>> inputData = null;
-    inputData =
-        Arrays.asList(
-            Map.of(
-                "id",
-                1L,
-                "date",
-                LocalDate.parse("2024-02-02"),
-                "timestamp",
-                LocalDateTime.parse("2024-04-04T12:00:00"),
-                "name",
-                "John Doe",
-                "operation_type",
-                "U"),
-            Map.of(
-                "id",
-                3L,
-                "date",
-                LocalDate.parse("2025-01-03"),
-                "timestamp",
-                LocalDateTime.parse("2025-02-02T06:06:06"),
-                "name",
-                "Bob",
-                "operation_type",
-                "I"));
-    String changeSql = TestUtil.createChangeSql(inputData, schema);
-    swiftLakeEngine
-        .applyChangesAsSCD1(tableName)
-        .tableFilterSql("id IS NOT NULL")
-        .sourceSql(changeSql)
-        .keyColumns(Arrays.asList("id"))
-        .operationTypeColumn("operation_type", "D")
-        .processSourceTables(false)
-        .execute();
+    if (isSnapshotMode) {
+      inputData =
+          Arrays.asList(
+              Map.of(
+                  "id",
+                  1L,
+                  "date",
+                  LocalDate.parse("2024-02-02"),
+                  "timestamp",
+                  LocalDateTime.parse("2024-04-04T12:00:00"),
+                  "name",
+                  "John Doe"),
+              Map.of(
+                  "id",
+                  3L,
+                  "date",
+                  LocalDate.parse("2025-01-03"),
+                  "timestamp",
+                  LocalDateTime.parse("2025-02-02T06:06:06"),
+                  "name",
+                  "Bob"),
+              Map.of(
+                  "id",
+                  2L,
+                  "date",
+                  LocalDate.parse("2025-01-02"),
+                  "timestamp",
+                  LocalDateTime.parse("2025-01-01T02:45:33"),
+                  "name",
+                  "Jane"));
+    } else {
+      inputData =
+          Arrays.asList(
+              Map.of(
+                  "id",
+                  1L,
+                  "date",
+                  LocalDate.parse("2024-02-02"),
+                  "timestamp",
+                  LocalDateTime.parse("2024-04-04T12:00:00"),
+                  "name",
+                  "John Doe",
+                  "operation_type",
+                  "U"),
+              Map.of(
+                  "id",
+                  3L,
+                  "date",
+                  LocalDate.parse("2025-01-03"),
+                  "timestamp",
+                  LocalDateTime.parse("2025-02-02T06:06:06"),
+                  "name",
+                  "Bob",
+                  "operation_type",
+                  "I"));
+    }
+
+    if (isSnapshotMode) {
+      String snapshotSql = TestUtil.createSelectSql(inputData, schema);
+      swiftLakeEngine
+          .applySnapshotAsSCD1(tableName)
+          .tableFilterSql("id IS NOT NULL")
+          .sourceSql(snapshotSql)
+          .keyColumns(Arrays.asList("id"))
+          .processSourceTables(false)
+          .execute();
+    } else {
+      String changeSql = TestUtil.createChangeSql(inputData, schema);
+      swiftLakeEngine
+          .applyChangesAsSCD1(tableName)
+          .tableFilterSql("id IS NOT NULL")
+          .sourceSql(changeSql)
+          .keyColumns(Arrays.asList("id"))
+          .operationTypeColumn("operation_type", "D")
+          .processSourceTables(false)
+          .execute();
+    }
 
     // Verify the results
     List<Map<String, Object>> actualData = TestUtil.getRecordsFromTable(swiftLakeEngine, tableName);
@@ -1176,50 +2164,126 @@ public class SCD1MergeBasicIntegrationTest {
 
   private static Stream<Arguments> providePartitionStrategies() {
     Schema schema = getSchemaForPartitionStrategiesTest();
-    return Stream.of(
-        Arguments.of(PartitionSpec.unpartitioned(), Arrays.asList(Pair.of("", 3L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).identity("id").build(),
-            Arrays.asList(Pair.of("id=1", 1L), Pair.of("id=2", 1L), Pair.of("id=3", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).year("date").build(),
-            Arrays.asList(Pair.of("date_year=2024", 1L), Pair.of("date_year=2025", 2L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).identity("id").year("date").build(),
-            Arrays.asList(
-                Pair.of("id=1/date_year=2024", 1L),
-                Pair.of("id=2/date_year=2025", 1L),
-                Pair.of("id=3/date_year=2025", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).month("date").bucket("id", 5).build(),
-            Arrays.asList(
-                Pair.of("date_month=2024-02/id_bucket=1", 1L),
-                Pair.of("date_month=2025-01/id_bucket=0", 1L),
-                Pair.of("date_month=2025-01/id_bucket=2", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).month("date").truncate("name", 3).build(),
-            Arrays.asList(
-                Pair.of("date_month=2024-02/name_trunc=Joh", 1L),
-                Pair.of("date_month=2025-01/name_trunc=Jan", 1L),
-                Pair.of("date_month=2025-01/name_trunc=Bob", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).hour("timestamp").identity("date").build(),
-            Arrays.asList(
-                Pair.of("timestamp_hour=2025-01-01-02/date=2025-01-02", 1L),
-                Pair.of("timestamp_hour=2024-04-04-12/date=2024-02-02", 1L),
-                Pair.of("timestamp_hour=2025-02-02-06/date=2025-01-03", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).day("timestamp").truncate("id", 2).build(),
-            Arrays.asList(
-                Pair.of("timestamp_day=2024-04-04/id_trunc=0", 1L),
-                Pair.of("timestamp_day=2025-01-01/id_trunc=2", 1L),
-                Pair.of("timestamp_day=2025-02-02/id_trunc=2", 1L))),
-        Arguments.of(
-            PartitionSpec.builderFor(schema).month("timestamp").month("date").build(),
-            Arrays.asList(
-                Pair.of("timestamp_month=2025-01/date_month=2025-01", 1L),
-                Pair.of("timestamp_month=2024-04/date_month=2024-02", 1L),
-                Pair.of("timestamp_month=2025-02/date_month=2025-01", 1L))));
+    List<Arguments> baseArguments =
+        Arrays.asList(
+            Arguments.of(PartitionSpec.unpartitioned(), Arrays.asList(Pair.of("", 3L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).identity("id").build(),
+                Arrays.asList(Pair.of("id=1", 1L), Pair.of("id=2", 1L), Pair.of("id=3", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).year("date").build(),
+                Arrays.asList(Pair.of("date_year=2024", 1L), Pair.of("date_year=2025", 2L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).identity("id").year("date").build(),
+                Arrays.asList(
+                    Pair.of("id=1/date_year=2024", 1L),
+                    Pair.of("id=2/date_year=2025", 1L),
+                    Pair.of("id=3/date_year=2025", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).month("date").bucket("id", 5).build(),
+                Arrays.asList(
+                    Pair.of("date_month=2024-02/id_bucket=1", 1L),
+                    Pair.of("date_month=2025-01/id_bucket=0", 1L),
+                    Pair.of("date_month=2025-01/id_bucket=2", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).month("date").truncate("name", 3).build(),
+                Arrays.asList(
+                    Pair.of("date_month=2024-02/name_trunc=Joh", 1L),
+                    Pair.of("date_month=2025-01/name_trunc=Jan", 1L),
+                    Pair.of("date_month=2025-01/name_trunc=Bob", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).hour("timestamp").identity("date").build(),
+                Arrays.asList(
+                    Pair.of("timestamp_hour=2025-01-01-02/date=2025-01-02", 1L),
+                    Pair.of("timestamp_hour=2024-04-04-12/date=2024-02-02", 1L),
+                    Pair.of("timestamp_hour=2025-02-02-06/date=2025-01-03", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).day("timestamp").truncate("id", 2).build(),
+                Arrays.asList(
+                    Pair.of("timestamp_day=2024-04-04/id_trunc=0", 1L),
+                    Pair.of("timestamp_day=2025-01-01/id_trunc=2", 1L),
+                    Pair.of("timestamp_day=2025-02-02/id_trunc=2", 1L))),
+            Arguments.of(
+                PartitionSpec.builderFor(schema).month("timestamp").month("date").build(),
+                Arrays.asList(
+                    Pair.of("timestamp_month=2025-01/date_month=2025-01", 1L),
+                    Pair.of("timestamp_month=2024-04/date_month=2024-02", 1L),
+                    Pair.of("timestamp_month=2025-02/date_month=2025-01", 1L))));
+
+    List<Arguments> allArguments = new ArrayList<>();
+    for (Arguments baseArgument : baseArguments) {
+      Object[] baseArgs = baseArgument.get();
+
+      // Create arguments for changes mode (isSnapshotMode = false)
+      Object[] changesArgs = Arrays.copyOf(baseArgs, baseArgs.length + 1);
+      changesArgs[baseArgs.length] = false;
+      allArguments.add(Arguments.of(changesArgs));
+
+      // Create arguments for snapshot mode (isSnapshotMode = true)
+      Object[] snapshotArgs = Arrays.copyOf(baseArgs, baseArgs.length + 1);
+      snapshotArgs[baseArgs.length] = true;
+      allArguments.add(Arguments.of(snapshotArgs));
+    }
+
+    return allArguments.stream();
+  }
+
+  @Test
+  @Execution(ExecutionMode.CONCURRENT)
+  void testSnapshotModeConcurrentOperations() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("id").build();
+
+    TableIdentifier tableId =
+        TableIdentifier.of("test_db", "scd1_snapshot_concurrent_operations_test");
+    swiftLakeEngine
+        .getCatalog()
+        .createTable(tableId, schema, partitionSpec, Map.of("commit.retry.num-retries", "10"));
+    String tableName = tableId.toString();
+
+    List<Map<String, Object>> expectedData = new ArrayList<>();
+
+    // Perform multiple concurrent snapshot operations
+    for (int j = 0; j < 3; j++) {
+      int index = j;
+      IntStream.range(0, 10)
+          .parallel()
+          .forEach(
+              i -> {
+                List<Map<String, Object>> data =
+                    Arrays.asList(Map.of("id", (long) i, "name", "name_" + i + index));
+                String sourceSql = TestUtil.createSelectSql(data, schema);
+                swiftLakeEngine
+                    .applySnapshotAsSCD1(tableName)
+                    .tableFilterSql("id = " + i)
+                    .sourceSql(sourceSql)
+                    .keyColumns(Arrays.asList("id"))
+                    .processSourceTables(false)
+                    .execute();
+              });
+    }
+
+    expectedData.addAll(
+        IntStream.range(0, 10)
+            .mapToObj(
+                i ->
+                    new HashMap<String, Object>() {
+                      {
+                        put("id", (long) i);
+                        put("name", "name_" + i + 2); // Last iteration's value should win
+                      }
+                    })
+            .collect(Collectors.toList()));
+
+    // Verify the results
+    List<Map<String, Object>> actualData = TestUtil.getRecordsFromTable(swiftLakeEngine, tableName);
+    assertThat(actualData)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyInAnyOrderElementsOf(expectedData);
+    TestUtil.dropIcebergTable(swiftLakeEngine, tableName);
   }
 
   @Test
@@ -1282,6 +2346,121 @@ public class SCD1MergeBasicIntegrationTest {
   }
 
   @Test
+  void testPartitionEvolutionWithSnapshotMode() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.required(3, "year", Types.IntegerType.get()),
+            Types.NestedField.required(4, "month", Types.IntegerType.get()),
+            Types.NestedField.required(5, "value", Types.DoubleType.get()));
+
+    // Start with partitioning by year
+    PartitionSpec initialSpec = PartitionSpec.builderFor(schema).identity("year").build();
+    TableIdentifier tableId =
+        TableIdentifier.of("test_db", "scd1_snapshot_partition_evolution_data_movement_test");
+    swiftLakeEngine.getCatalog().createTable(tableId, schema, initialSpec);
+    String tableName = tableId.toString();
+
+    // Initial data
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John", "year", 2025, "month", 1, "value", 100.0),
+            Map.of("id", 2L, "name", "Jane", "year", 2025, "month", 2, "value", 200.0));
+
+    swiftLakeEngine
+        .insertInto(tableName)
+        .sql(TestUtil.createSelectSql(initialData, schema))
+        .processSourceTables(false)
+        .execute();
+
+    // Snapshot data with changes
+    List<Map<String, Object>> snapshot1 =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John Doe", "year", 2025, "month", 1, "value", 150.0),
+            Map.of("id", 2L, "name", "Jane", "year", 2025, "month", 2, "value", 200.0),
+            Map.of("id", 3L, "name", "Bob", "year", 2025, "month", 3, "value", 300.0));
+
+    // Apply first snapshot
+    String sourceSql1 = TestUtil.createSelectSql(snapshot1, schema);
+    swiftLakeEngine
+        .applySnapshotAsSCD1(tableName)
+        .tableFilterSql("id IS NOT NULL")
+        .sourceSql(sourceSql1)
+        .keyColumns(Arrays.asList("id"))
+        .processSourceTables(false)
+        .execute();
+
+    // Evolve partition spec to include month
+    swiftLakeEngine.getTable(tableName).updateSpec().addField("month").commit();
+
+    // Second snapshot data with more changes
+    List<Map<String, Object>> snapshot2 =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John Doe", "year", 2025, "month", 1, "value", 150.0),
+            Map.of(
+                "id",
+                2L,
+                "name",
+                "Jane Doe", // changed
+                "year",
+                2025,
+                "month",
+                2,
+                "value",
+                250.0), // changed
+            Map.of("id", 3L, "name", "Bob", "year", 2025, "month", 3, "value", 300.0),
+            Map.of("id", 4L, "name", "Alice", "year", 2025, "month", 4, "value", 400.0)); // new
+
+    // Apply second snapshot with new partition spec
+    String sourceSql2 = TestUtil.createSelectSql(snapshot2, schema);
+    swiftLakeEngine
+        .applySnapshotAsSCD1(tableName)
+        .tableFilterSql("id IS NOT NULL")
+        .sourceSql(sourceSql2)
+        .keyColumns(Arrays.asList("id"))
+        .processSourceTables(false)
+        .execute();
+
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John Doe", "year", 2025, "month", 1, "value", 150.0),
+            Map.of("id", 2L, "name", "Jane Doe", "year", 2025, "month", 2, "value", 250.0),
+            Map.of("id", 3L, "name", "Bob", "year", 2025, "month", 3, "value", 300.0),
+            Map.of("id", 4L, "name", "Alice", "year", 2025, "month", 4, "value", 400.0));
+
+    List<Map<String, Object>> actualData = TestUtil.getRecordsFromTable(swiftLakeEngine, tableName);
+    assertThat(actualData)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyInAnyOrderElementsOf(expectedData);
+
+    // Verify that data is properly partitioned
+    List<DataFile> dataFiles =
+        swiftLakeEngine
+            .getIcebergScanExecutor()
+            .executeTableScan(swiftLakeEngine.getTable(tableName), Expressions.alwaysTrue())
+            .getScanResult()
+            .getValue();
+    assertThat(dataFiles).hasSize(4);
+    var partitions =
+        dataFiles.stream()
+            .map(
+                f ->
+                    Arrays.asList(
+                        f.partition().get(0, Integer.class), f.partition().get(1, Integer.class)))
+            .collect(Collectors.toList());
+    assertThat(partitions)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyInAnyOrderElementsOf(
+            Arrays.asList(
+                Arrays.asList(2025, 1),
+                Arrays.asList(2025, 2),
+                Arrays.asList(2025, 3),
+                Arrays.asList(2025, 4)));
+    TestUtil.dropIcebergTable(swiftLakeEngine, tableName);
+  }
+
+  @Test
   void testPartitionEvolutionWithDataMovement() {
     Schema schema =
         new Schema(
@@ -1311,8 +2490,7 @@ public class SCD1MergeBasicIntegrationTest {
         .execute();
 
     // Perform first SCD1 merge
-    List<Map<String, Object>> inputData1 = null;
-    inputData1 =
+    List<Map<String, Object>> inputData1 =
         Arrays.asList(
             Map.of(
                 "id",
@@ -1354,8 +2532,7 @@ public class SCD1MergeBasicIntegrationTest {
     swiftLakeEngine.getTable(tableName).updateSpec().addField("month").commit();
 
     // Perform second SCD1 merge with new partition spec
-    List<Map<String, Object>> inputData2 = null;
-    inputData2 =
+    List<Map<String, Object>> inputData2 =
         Arrays.asList(
             Map.of(
                 "id",
@@ -1431,16 +2608,640 @@ public class SCD1MergeBasicIntegrationTest {
     TestUtil.dropIcebergTable(swiftLakeEngine, tableName);
   }
 
+  private static Arguments valueColumnsTestCase() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "value", Types.DoubleType.get()),
+            Types.NestedField.optional(4, "salary", Types.DoubleType.get()),
+            Types.NestedField.optional(5, "status", Types.StringType.get()),
+            Types.NestedField.optional(6, "created_at", Types.TimestampType.withoutZone()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    // Initial data
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of(
+                "id",
+                1,
+                "name",
+                "John",
+                "value",
+                100.0,
+                "salary",
+                50.0,
+                "status",
+                "Active",
+                "created_at",
+                LocalDateTime.parse("2023-01-01T12:00:00")));
+
+    // Input data - only name and value should be considered for value comparison
+    List<Map<String, Object>> inputData =
+        Arrays.asList(
+            Map.of(
+                "id",
+                1,
+                "name",
+                "John",
+                "value",
+                100.0,
+                "salary",
+                60.0, // changed
+                "status",
+                "Updated", // changed
+                "created_at",
+                LocalDateTime.parse("2023-02-01T12:00:00"))); // changed
+
+    // Expected result - only specified value columns should be compared
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of(
+                "id",
+                1,
+                "name",
+                "John",
+                "value",
+                100.0,
+                "salary",
+                50.0, // unchanged because not in valueColumns
+                "status",
+                "Active", // unchanged because not in valueColumns
+                "created_at",
+                LocalDateTime.parse("2023-01-01T12:00:00"))); // unchanged
+
+    List<String> keyColumns = Arrays.asList("id");
+    List<String> valueColumns = Arrays.asList("name", "value");
+    String tableFilter = "id = 1";
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, true, valueColumns, null, null);
+
+    return Arguments.of(
+        "value_columns",
+        schema,
+        partitionSpec,
+        initialData,
+        Arrays.asList(mergeInput),
+        expectedData,
+        null,
+        null);
+  }
+
+  private static Arguments valueColumnsWithMaxDeltaTestCase() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "value", Types.DoubleType.get()),
+            Types.NestedField.optional(4, "salary", Types.DoubleType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    // Initial data
+    List<Map<String, Object>> initialData =
+        Arrays.asList(Map.of("id", 1, "name", "John", "value", 100.0, "salary", 50.0));
+
+    // Input sequence
+    List<SCD1MergeInput> mergeInputs = new ArrayList<>();
+
+    // First update - small delta within tolerance
+    List<Map<String, Object>> inputData1 =
+        Arrays.asList(Map.of("id", 1, "name", "John", "value", 100.01, "salary", 50.3));
+
+    Map<String, ValueColumnMetadata<?>> valueMetadata1 = new HashMap<>();
+    valueMetadata1.put("value", new ValueColumnMetadata<>(0.1, null));
+    valueMetadata1.put("salary", new ValueColumnMetadata<>(0.5, null));
+
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData1,
+            "id = 1",
+            Arrays.asList("id"),
+            true,
+            Arrays.asList("name", "value", "salary"),
+            valueMetadata1,
+            null));
+
+    // Second update - one change exceeds tolerance
+    List<Map<String, Object>> inputData2 =
+        Arrays.asList(
+            Map.of(
+                "id", 1, "name", "John", "value", 100.02, "salary",
+                55.0)); // exceeds the 0.5 delta threshold
+
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData2,
+            "id = 1",
+            Arrays.asList("id"),
+            true,
+            Arrays.asList("name", "value", "salary"),
+            valueMetadata1,
+            null));
+
+    // Expected result - after the second update, salary should have changed
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of(
+                "id", 1, "name", "John", "value", 100.02, // small change
+                "salary", 55.0)); // exceeded threshold
+
+    return Arguments.of(
+        "value_columns_max_delta",
+        schema,
+        partitionSpec,
+        initialData,
+        mergeInputs,
+        expectedData,
+        null,
+        null);
+  }
+
+  private static Arguments valueColumnsWithNullReplacementTestCase() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "value", Types.DoubleType.get()),
+            Types.NestedField.optional(4, "salary", Types.DoubleType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    // Initial data
+    List<Map<String, Object>> initialData =
+        Arrays.asList(Map.of("id", 1, "name", "John", "value", 100.0, "salary", 50.0));
+
+    // Input data with nulls treated as specific values
+    Map<String, Object> nullData = new HashMap<>();
+    nullData.put("id", 1);
+    nullData.put("name", "John");
+    nullData.put("value", null);
+    nullData.put("salary", null);
+
+    List<Map<String, Object>> inputData = Arrays.asList(nullData);
+
+    Map<String, ValueColumnMetadata<?>> valueMetadata1 = new HashMap<>();
+    valueMetadata1.put("value", new ValueColumnMetadata<>(null, 100.0));
+    valueMetadata1.put("salary", new ValueColumnMetadata<>(null, 50.0));
+
+    List<SCD1MergeInput> mergeInputs = new ArrayList<>();
+    List<String> keyColumns = Arrays.asList("id");
+    List<String> valueColumns = Arrays.asList("name", "value", "salary");
+    String tableFilter = "id = 1";
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData, tableFilter, keyColumns, true, valueColumns, valueMetadata1, null));
+
+    // Second update - nulls with different replacement values
+    Map<String, Object> nullData2 = new HashMap<>();
+    nullData2.put("id", 1);
+    nullData2.put("name", "John");
+    nullData2.put("value", null);
+    nullData2.put("salary", null);
+
+    List<Map<String, Object>> inputData2 = Arrays.asList(nullData2);
+
+    Map<String, ValueColumnMetadata<?>> valueMetadata2 = new HashMap<>();
+    valueMetadata2.put("value", new ValueColumnMetadata<>(null, 0.0));
+    valueMetadata2.put("salary", new ValueColumnMetadata<>(null, 1.0));
+
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData2, tableFilter, keyColumns, true, valueColumns, valueMetadata2, null));
+
+    // Third update - mixed nulls and non-nulls
+    Map<String, Object> mixedData = new HashMap<>();
+    mixedData.put("id", 1);
+    mixedData.put("name", "John");
+    mixedData.put("value", 200.0);
+    mixedData.put("salary", null);
+
+    List<Map<String, Object>> inputData3 = Arrays.asList(mixedData);
+
+    Map<String, ValueColumnMetadata<?>> valueMetadata3 = new HashMap<>();
+    valueMetadata3.put("value", new ValueColumnMetadata<>(null, 0.0));
+    valueMetadata3.put("salary", new ValueColumnMetadata<>(null, 0.0));
+
+    mergeInputs.add(
+        new SCD1MergeInput(
+            inputData3, tableFilter, keyColumns, true, valueColumns, valueMetadata3, null));
+
+    // Expected final state
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("id", 1);
+    expected.put("name", "John");
+    expected.put("value", 200.0);
+    expected.put("salary", null);
+
+    List<Map<String, Object>> expectedData = Arrays.asList(expected);
+    return Arguments.of(
+        "value_columns_null_replacement",
+        schema,
+        partitionSpec,
+        initialData,
+        mergeInputs,
+        expectedData,
+        null,
+        null);
+  }
+
+  private static Arguments skipEmptySourceTestCase() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "value", Types.DoubleType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    // Initial data
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of("id", 1, "name", "John", "value", 100.0),
+            Map.of("id", 2, "name", "Jane", "value", 200.0));
+
+    // Empty source data
+    List<Map<String, Object>> emptyInputData = new ArrayList<>();
+
+    // Test multiple scenarios with empty source
+    List<SCD1MergeInput> mergeInputs = new ArrayList<>();
+
+    // First test: skipEmptySource=true - should not delete records
+    mergeInputs.add(
+        new SCD1MergeInput(
+            emptyInputData,
+            "id = 1",
+            Arrays.asList("id"),
+            true,
+            null,
+            null,
+            true)); // skip empty source
+
+    // Second test: skipEmptySource=false - should delete records matching the filter
+    mergeInputs.add(
+        new SCD1MergeInput(
+            emptyInputData,
+            "id = 2",
+            Arrays.asList("id"),
+            true,
+            null,
+            null,
+            false)); // don't skip empty source
+
+    // After the first operation, nothing should change
+    // After the second operation, id=2 should be deleted
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(Map.of("id", 1, "name", "John", "value", 100.0));
+
+    return Arguments.of(
+        "skip_empty_source",
+        schema,
+        partitionSpec,
+        initialData,
+        mergeInputs,
+        expectedData,
+        null,
+        null);
+  }
+
+  private static Arguments replaceAllTestCase(boolean isSnapshotMode) {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of("id", 1L, "name", "John"),
+            Map.of("id", 2L, "name", "Jane"),
+            Map.of("id", 3L, "name", "Bob"));
+
+    List<List<Map<String, Object>>> inputDataList;
+
+    if (isSnapshotMode) {
+      inputDataList =
+          Arrays.asList(
+              // First snapshot removes Bob, updates John
+              Arrays.asList(Map.of("id", 1L, "name", "John Doe"), Map.of("id", 2L, "name", "Jane")),
+              // Second snapshot replaces all with completely new data
+              Arrays.asList(
+                  Map.of("id", 4L, "name", "Alice"),
+                  Map.of("id", 5L, "name", "Charlie"),
+                  Map.of("id", 6L, "name", "David")));
+    } else {
+      // Changes mode equivalent operations
+      inputDataList =
+          Arrays.asList(
+              // First set of changes: update John, delete Bob
+              Arrays.asList(
+                  Map.of("id", 1L, "name", "John Doe", "operation_type", "U"),
+                  Map.of("id", 3L, "name", "Bob", "operation_type", "D")),
+              // Second set of changes: delete existing records, insert new ones
+              Arrays.asList(
+                  Map.of("id", 1L, "name", "John Doe", "operation_type", "D"),
+                  Map.of("id", 2L, "name", "Jane", "operation_type", "D"),
+                  Map.of("id", 4L, "name", "Alice", "operation_type", "I"),
+                  Map.of("id", 5L, "name", "Charlie", "operation_type", "I"),
+                  Map.of("id", 6L, "name", "David", "operation_type", "I")));
+    }
+
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of("id", 4L, "name", "Alice"),
+            Map.of("id", 5L, "name", "Charlie"),
+            Map.of("id", 6L, "name", "David"));
+
+    List<String> keyColumns = Arrays.asList("id");
+    String tableFilter = "id IS NOT NULL";
+    List<SCD1MergeInput> mergeInputs =
+        inputDataList.stream()
+            .map(
+                inputData -> new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode))
+            .collect(Collectors.toList());
+
+    return Arguments.of(
+        "replace_all" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
+        schema,
+        partitionSpec,
+        initialData,
+        mergeInputs,
+        expectedData,
+        null,
+        null);
+  }
+
+  private static Arguments partialMergeWithFiltersTestCase(boolean isSnapshotMode) {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "region", Types.StringType.get()),
+            Types.NestedField.required(3, "value", Types.DoubleType.get()));
+    PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("region").build();
+
+    // Initial data with multiple regions
+    List<Map<String, Object>> initialData =
+        Arrays.asList(
+            Map.of("id", 1L, "region", "EMEA", "value", 100.0),
+            Map.of("id", 2L, "region", "EMEA", "value", 200.0),
+            Map.of("id", 3L, "region", "APAC", "value", 300.0),
+            Map.of("id", 4L, "region", "APAC", "value", 400.0),
+            Map.of("id", 5L, "region", "AMER", "value", 500.0));
+
+    List<Map<String, Object>> inputData;
+
+    if (isSnapshotMode) {
+      // Snapshot data for EMEA region only
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "region", "EMEA", "value", 110.0),
+              Map.of("id", 2L, "region", "EMEA", "value", 220.0),
+              Map.of("id", 6L, "region", "EMEA", "value", 600.0));
+    } else {
+      // Changes mode equivalent
+      inputData =
+          Arrays.asList(
+              Map.of("id", 1L, "region", "EMEA", "value", 110.0, "operation_type", "U"),
+              Map.of("id", 2L, "region", "EMEA", "value", 220.0, "operation_type", "U"),
+              Map.of("id", 6L, "region", "EMEA", "value", 600.0, "operation_type", "I"));
+    }
+
+    // Expected data - EMEA records updated/added/deleted as specified in the operation
+    // but APAC and AMER records are left untouched
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of("id", 1L, "region", "EMEA", "value", 110.0),
+            Map.of("id", 2L, "region", "EMEA", "value", 220.0),
+            Map.of("id", 6L, "region", "EMEA", "value", 600.0),
+            Map.of("id", 3L, "region", "APAC", "value", 300.0),
+            Map.of("id", 4L, "region", "APAC", "value", 400.0),
+            Map.of("id", 5L, "region", "AMER", "value", 500.0));
+
+    List<String> keyColumns = Arrays.asList("id");
+    String tableFilter = "region = 'EMEA'"; // Filter only affects EMEA records
+    SCD1MergeInput mergeInput =
+        new SCD1MergeInput(inputData, tableFilter, keyColumns, isSnapshotMode);
+
+    return Arguments.of(
+        "partial_merge_with_filters" + (isSnapshotMode ? "_snapshot_mode" : "_changes_mode"),
+        schema,
+        partitionSpec,
+        initialData,
+        Arrays.asList(mergeInput),
+        expectedData,
+        null,
+        null);
+  }
+
+  @Test
+  void testFilesSkippedWithNoChanges() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.required(3, "value", Types.DoubleType.get()),
+            Types.NestedField.required(4, "salary", Types.DoubleType.get()),
+            Types.NestedField.required(5, "status", Types.StringType.get()),
+            Types.NestedField.optional(6, "created_at", Types.TimestampType.withoutZone()));
+
+    // Create table
+    TableIdentifier tableId = TableIdentifier.of("test_db", "files_skipped_test");
+    Table testTable = swiftLakeEngine.getCatalog().createTable(tableId, schema);
+    String tableName = tableId.toString();
+
+    // Insert data in multiple batches to create different data files
+    String initialInsertSql1 =
+        "SELECT * FROM (VALUES"
+            + "(1, 'A1', 100.0, 50.0, 'A', TIMESTAMP '2023-01-01 12:00:00'),"
+            + "(2, 'A2', 200.0, 60.0, 'A', TIMESTAMP '2023-01-01 12:00:00')"
+            + ") AS t(id, name, value, salary, status, created_at)";
+    swiftLakeEngine
+        .insertInto(tableName)
+        .sql(initialInsertSql1)
+        .processSourceTables(false)
+        .execute();
+
+    String initialInsertSql2 =
+        "SELECT * FROM (VALUES"
+            + "(3, 'B1', 300.0, 70.0, 'B', TIMESTAMP '2023-01-01 12:00:00'),"
+            + "(4, 'B2', 400.0, 80.0, 'B', TIMESTAMP '2023-01-01 12:00:00')"
+            + ") AS t(id, name, value, salary, status, created_at)";
+    swiftLakeEngine
+        .insertInto(tableName)
+        .sql(initialInsertSql2)
+        .processSourceTables(false)
+        .execute();
+
+    String initialInsertSql3 =
+        "SELECT * FROM (VALUES"
+            + "(5, 'C1', 500.0, 90.0, 'C', TIMESTAMP '2023-01-01 12:00:00')"
+            + ") AS t(id, name, value, salary, status, created_at)";
+    swiftLakeEngine
+        .insertInto(tableName)
+        .sql(initialInsertSql3)
+        .processSourceTables(false)
+        .execute();
+
+    // Apply snapshot merge that only changes some records
+    String updateSql =
+        "SELECT * FROM (VALUES"
+            + "(1, 'A1 Updated', 150.0, 50.0, 'A', TIMESTAMP '2023-01-01 12:00:00'),"
+            + "(2, 'A2', 200.0, 65.0, 'A', TIMESTAMP '2023-01-01 12:00:00'),"
+            + "(3, 'B1', 300.0, 70.0, 'B', TIMESTAMP '2023-01-01 12:00:00'),"
+            + "(4, 'B2', 400.0, 80.0, 'B', TIMESTAMP '2023-01-01 12:00:00')"
+            + ") AS t(id, name, value, salary, status, created_at)";
+
+    CommitMetrics commitMetrics =
+        swiftLakeEngine
+            .applySnapshotAsSCD1(testTable)
+            .tableFilterSql("status IN ('A', 'B')") // Filter includes categories A and B
+            .sourceSql(updateSql)
+            .keyColumns(Arrays.asList("id"))
+            .valueColumns(Arrays.asList("name", "value", "salary")) // Only these are value columns
+            .execute();
+
+    // Verify metrics
+    assertThat(commitMetrics.getRemovedFilesCount()).isEqualTo(1);
+    assertThat(commitMetrics.getAddedFilesCount()).isEqualTo(1);
+
+    // Verify results
+    List<Map<String, Object>> actualData = TestUtil.getRecordsFromTable(swiftLakeEngine, tableName);
+    List<Map<String, Object>> expectedData =
+        Arrays.asList(
+            Map.of(
+                "id",
+                1L,
+                "name",
+                "A1 Updated",
+                "value",
+                150.0,
+                "salary",
+                50.0,
+                "status",
+                "A",
+                "created_at",
+                TestUtil.parseTimestamp("2023-01-01 12:00:00")),
+            Map.of(
+                "id",
+                2L,
+                "name",
+                "A2",
+                "value",
+                200.0,
+                "salary",
+                65.0,
+                "status",
+                "A",
+                "created_at",
+                TestUtil.parseTimestamp("2023-01-01 12:00:00")),
+            Map.of(
+                "id",
+                3L,
+                "name",
+                "B1",
+                "value",
+                300.0,
+                "salary",
+                70.0,
+                "status",
+                "B",
+                "created_at",
+                TestUtil.parseTimestamp("2023-01-01 12:00:00")),
+            Map.of(
+                "id",
+                4L,
+                "name",
+                "B2",
+                "value",
+                400.0,
+                "salary",
+                80.0,
+                "status",
+                "B",
+                "created_at",
+                TestUtil.parseTimestamp("2023-01-01 12:00:00")),
+            Map.of(
+                "id",
+                5L,
+                "name",
+                "C1",
+                "value",
+                500.0,
+                "salary",
+                90.0,
+                "status",
+                "C",
+                "created_at",
+                TestUtil.parseTimestamp("2023-01-01 12:00:00")));
+
+    assertThat(actualData)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyInAnyOrderElementsOf(expectedData);
+
+    // Clean up
+    TestUtil.dropIcebergTable(swiftLakeEngine, tableName);
+  }
+
   public static class SCD1MergeInput {
     List<Map<String, Object>> inputData;
     String tableFilter;
     List<String> keyColumns;
+    boolean isSnapshot;
+    List<String> valueColumns;
+    Map<String, ValueColumnMetadata<?>> valueColumnMetadata;
+    Boolean skipEmptySource;
+    String operationTypeColumn;
+    String deleteOperationValue;
 
     public SCD1MergeInput(
         List<Map<String, Object>> inputData, String tableFilter, List<String> keyColumns) {
+      this(inputData, tableFilter, keyColumns, false, null, null, null);
+    }
+
+    public SCD1MergeInput(
+        List<Map<String, Object>> inputData,
+        String tableFilter,
+        List<String> keyColumns,
+        boolean isSnapshot) {
+      this(inputData, tableFilter, keyColumns, isSnapshot, null, null, null);
+    }
+
+    public SCD1MergeInput(
+        List<Map<String, Object>> inputData,
+        String tableFilter,
+        List<String> keyColumns,
+        boolean isSnapshot,
+        List<String> valueColumns,
+        Map<String, ValueColumnMetadata<?>> valueColumnMetadata,
+        Boolean skipEmptySource) {
+      this(
+          inputData,
+          tableFilter,
+          keyColumns,
+          isSnapshot,
+          valueColumns,
+          valueColumnMetadata,
+          skipEmptySource,
+          isSnapshot ? null : "operation_type",
+          isSnapshot ? null : "D");
+    }
+
+    public SCD1MergeInput(
+        List<Map<String, Object>> inputData,
+        String tableFilter,
+        List<String> keyColumns,
+        boolean isSnapshot,
+        List<String> valueColumns,
+        Map<String, ValueColumnMetadata<?>> valueColumnMetadata,
+        Boolean skipEmptySource,
+        String operationTypeColumn,
+        String deleteOperationValue) {
       this.inputData = inputData;
       this.tableFilter = tableFilter;
       this.keyColumns = keyColumns;
+      this.isSnapshot = isSnapshot;
+      this.valueColumns = valueColumns;
+      this.valueColumnMetadata = valueColumnMetadata;
+      this.skipEmptySource = skipEmptySource;
+      this.operationTypeColumn = operationTypeColumn;
+      this.deleteOperationValue = deleteOperationValue;
     }
   }
 }

--- a/core/src/test/java/com/arcesium/swiftlake/commands/ValueColumnMetadataTest.java
+++ b/core/src/test/java/com/arcesium/swiftlake/commands/ValueColumnMetadataTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Arcesium LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arcesium.swiftlake.commands;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ValueColumnMetadataTest {
+
+  @Test
+  void testBasicFunctionality() {
+    Double maxDeltaValue = 0.001;
+    String nullReplacement = "N/A";
+
+    ValueColumnMetadata<String> metadata =
+        new ValueColumnMetadata<>(maxDeltaValue, nullReplacement);
+
+    assertThat(metadata.getMaxDeltaValue()).isEqualTo(maxDeltaValue);
+    assertThat(metadata.getNullReplacement()).isEqualTo(nullReplacement);
+    assertThat(metadata.toString()).contains("maxDeltaValue=0.001", "nullReplacement=N/A");
+  }
+
+  @Test
+  void testWithNullValues() {
+    ValueColumnMetadata<String> metadata = new ValueColumnMetadata<>(null, null);
+
+    assertThat(metadata.getMaxDeltaValue()).isNull();
+    assertThat(metadata.getNullReplacement()).isNull();
+  }
+}

--- a/core/src/test/java/com/arcesium/swiftlake/common/DateTimeUtilTest.java
+++ b/core/src/test/java/com/arcesium/swiftlake/common/DateTimeUtilTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2025, Arcesium LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arcesium.swiftlake.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class DateTimeUtilTest {
+
+  @Test
+  void testParseLocalDate_validInput() {
+    LocalDate result = DateTimeUtil.parseLocalDate("2023-12-31");
+    assertThat(result).isEqualTo(LocalDate.of(2023, 12, 31));
+  }
+
+  @Test
+  void testParseLocalDate_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDate(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Date string cannot be null");
+  }
+
+  @Test
+  void testParseLocalDate_emptyInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDate(""))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Date string cannot be empty");
+  }
+
+  @Test
+  void testParseLocalDate_invalidFormat() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDate("31/12/2023"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Date '31/12/2023' must be in ISO format");
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_validInput() {
+    LocalTime result = DateTimeUtil.parseLocalTimeToMicros("14:30:45.123456");
+    assertThat(result).isEqualTo(LocalTime.of(14, 30, 45, 123456000));
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_simplifiedInput() {
+    LocalTime result = DateTimeUtil.parseLocalTimeToMicros("14:30:45");
+    assertThat(result).isEqualTo(LocalTime.of(14, 30, 45));
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_truncatesNanoseconds() {
+    LocalTime result = DateTimeUtil.parseLocalTimeToMicros("14:30:45.1234567");
+    assertThat(result).isEqualTo(LocalTime.of(14, 30, 45, 123456000));
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalTimeToMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Time string cannot be null");
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_emptyInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalTimeToMicros(""))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Time string cannot be empty");
+  }
+
+  @Test
+  void testParseLocalTimeToMicros_invalidFormat() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalTimeToMicros("2:30pm"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Time '2:30pm' must be in ISO format");
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_validInput() {
+    LocalDateTime result = DateTimeUtil.parseLocalDateTimeToMicros("2023-12-31T14:30:45.123456");
+    assertThat(result).isEqualTo(LocalDateTime.of(2023, 12, 31, 14, 30, 45, 123456000));
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_simplifiedInput() {
+    LocalDateTime result = DateTimeUtil.parseLocalDateTimeToMicros("2023-12-31T14:30:45");
+    assertThat(result).isEqualTo(LocalDateTime.of(2023, 12, 31, 14, 30, 45));
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_truncatesNanoseconds() {
+    LocalDateTime result = DateTimeUtil.parseLocalDateTimeToMicros("2023-12-31T14:30:45.1234567");
+    assertThat(result).isEqualTo(LocalDateTime.of(2023, 12, 31, 14, 30, 45, 123456000));
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDateTimeToMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Timestamp string cannot be null");
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_emptyInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDateTimeToMicros(""))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Timestamp string cannot be empty");
+  }
+
+  @Test
+  void testParseLocalDateTimeToMicros_invalidFormat() {
+    assertThatThrownBy(() -> DateTimeUtil.parseLocalDateTimeToMicros("12/31/2023 14:30:45"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Timestamp '12/31/2023 14:30:45' must be in ISO format");
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_validInput() {
+    OffsetDateTime result =
+        DateTimeUtil.parseOffsetDateTimeToMicros("2023-12-31T14:30:45.123456+01:00");
+    assertThat(result)
+        .isEqualTo(OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456000, ZoneOffset.ofHours(1)));
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_zulu() {
+    OffsetDateTime result = DateTimeUtil.parseOffsetDateTimeToMicros("2023-12-31T14:30:45.123456Z");
+    assertThat(result)
+        .isEqualTo(OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456000, ZoneOffset.UTC));
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_simplifiedInput() {
+    OffsetDateTime result = DateTimeUtil.parseOffsetDateTimeToMicros("2023-12-31T14:30:45+01:00");
+    assertThat(result)
+        .isEqualTo(OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 0, ZoneOffset.ofHours(1)));
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_truncatesNanoseconds() {
+    OffsetDateTime result =
+        DateTimeUtil.parseOffsetDateTimeToMicros("2023-12-31T14:30:45.1234567+01:00");
+    assertThat(result)
+        .isEqualTo(OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456000, ZoneOffset.ofHours(1)));
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseOffsetDateTimeToMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("TimestampTZ string cannot be null");
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_emptyInput() {
+    assertThatThrownBy(() -> DateTimeUtil.parseOffsetDateTimeToMicros(""))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("TimestampTZ string cannot be empty");
+  }
+
+  @Test
+  void testParseOffsetDateTimeToMicros_invalidFormat() {
+    assertThatThrownBy(() -> DateTimeUtil.parseOffsetDateTimeToMicros("12/31/2023 14:30:45 +01:00"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("TimestampTZ '12/31/2023 14:30:45 +01:00' must be in ISO format");
+  }
+
+  @Test
+  void testFormatLocalDate_validInput() {
+    LocalDate date = LocalDate.of(2023, 12, 31);
+    String result = DateTimeUtil.formatLocalDate(date);
+    assertThat(result).isEqualTo("2023-12-31");
+  }
+
+  @Test
+  void testFormatLocalDate_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.formatLocalDate(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Date value cannot be null");
+  }
+
+  @Test
+  void testFormatLocalTimeWithMicros_validInput() {
+    LocalTime time = LocalTime.of(14, 30, 45, 123456000);
+    String result = DateTimeUtil.formatLocalTimeWithMicros(time);
+    assertThat(result).isEqualTo("14:30:45.123456");
+  }
+
+  @Test
+  void testFormatLocalTimeWithMicros_truncatesNanoseconds() {
+    LocalTime time = LocalTime.of(14, 30, 45, 123456789);
+    String result = DateTimeUtil.formatLocalTimeWithMicros(time);
+    assertThat(result).isEqualTo("14:30:45.123456");
+  }
+
+  @Test
+  void testFormatLocalTimeWithMicros_noFractionalSeconds() {
+    LocalTime time = LocalTime.of(14, 30, 45);
+    String result = DateTimeUtil.formatLocalTimeWithMicros(time);
+    assertThat(result).isEqualTo("14:30:45");
+  }
+
+  @Test
+  void testFormatLocalTimeWithMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.formatLocalTimeWithMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Time value cannot be null");
+  }
+
+  @Test
+  void testFormatLocalDateTimeWithMicros_validInput() {
+    LocalDateTime dateTime = LocalDateTime.of(2023, 12, 31, 14, 30, 45, 123456000);
+    String result = DateTimeUtil.formatLocalDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45.123456");
+  }
+
+  @Test
+  void testFormatLocalDateTimeWithMicros_truncatesNanoseconds() {
+    LocalDateTime dateTime = LocalDateTime.of(2023, 12, 31, 14, 30, 45, 123456789);
+    String result = DateTimeUtil.formatLocalDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45.123456");
+  }
+
+  @Test
+  void testFormatLocalDateTimeWithMicros_noFractionalSeconds() {
+    LocalDateTime dateTime = LocalDateTime.of(2023, 12, 31, 14, 30, 45);
+    String result = DateTimeUtil.formatLocalDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45");
+  }
+
+  @Test
+  void testFormatLocalDateTimeWithMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.formatLocalDateTimeWithMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Timestamp value cannot be null");
+  }
+
+  @Test
+  void testFormatOffsetDateTimeWithMicros_validInput() {
+    OffsetDateTime dateTime =
+        OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456000, ZoneOffset.ofHours(1));
+    String result = DateTimeUtil.formatOffsetDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45.123456+01:00");
+  }
+
+  @Test
+  void testFormatOffsetDateTimeWithMicros_utcZone() {
+    OffsetDateTime dateTime =
+        OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456789, ZoneOffset.UTC);
+    String result = DateTimeUtil.formatOffsetDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45.123456Z");
+  }
+
+  @Test
+  void testFormatOffsetDateTimeWithMicros_truncatesNanoseconds() {
+    OffsetDateTime dateTime =
+        OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 123456789, ZoneOffset.ofHours(1));
+    String result = DateTimeUtil.formatOffsetDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45.123456+01:00");
+  }
+
+  @Test
+  void testFormatOffsetDateTimeWithMicros_noFractionalSeconds() {
+    OffsetDateTime dateTime = OffsetDateTime.of(2023, 12, 31, 14, 30, 45, 0, ZoneOffset.ofHours(1));
+    String result = DateTimeUtil.formatOffsetDateTimeWithMicros(dateTime);
+    assertThat(result).isEqualTo("2023-12-31T14:30:45+01:00");
+  }
+
+  @Test
+  void testFormatOffsetDateTimeWithMicros_nullInput() {
+    assertThatThrownBy(() -> DateTimeUtil.formatOffsetDateTimeWithMicros(null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("TimestampTZ value cannot be null");
+  }
+}

--- a/core/src/test/java/com/arcesium/swiftlake/dao/SCD1MergeDaoTest.java
+++ b/core/src/test/java/com/arcesium/swiftlake/dao/SCD1MergeDaoTest.java
@@ -53,27 +53,27 @@ class SCD1MergeDaoTest {
   }
 
   @Test
-  void testMergeFindDiffs() {
+  void testChangesBasedMergeFindDiffs() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     properties.setDestinationTableName("target_table");
     properties.setSourceTableName("source_table");
     when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
-    scd1MergeDao.mergeFindDiffs(properties);
+    scd1MergeDao.changesBasedMergeFindDiffs(properties);
 
-    verify(mockSqlSession).update("SCD1Merge.mergeFindDiffs", properties);
+    verify(mockSqlSession).update("SCD1Merge.changesBasedMergeFindDiffs", properties);
     verify(mockSqlSession).close();
   }
 
   @Test
-  void testGetMergeUpsertsSql() {
+  void testGetChangesBasedMergeResultsSql() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     properties.setDestinationTableName("target_table");
     properties.setSourceTableName("source_table");
 
-    String expectedSql = "testGetMergeUpsertsSql...";
-    when(mockSqlSessionFactory.getSql("SCD1Merge.mergeUpserts", properties))
+    String expectedSql = "testGetChangesBasedMergeResultsSql...";
+    when(mockSqlSessionFactory.getSql("SCD1Merge.changesBasedMergeResults", properties))
         .thenReturn(expectedSql);
-    String result = scd1MergeDao.getMergeUpsertsSql(properties);
+    String result = scd1MergeDao.getChangesBasedMergeResultsSql(properties);
 
     assertThat(result).isEqualTo(expectedSql);
   }
@@ -93,24 +93,24 @@ class SCD1MergeDaoTest {
   }
 
   @Test
-  void testSaveDistinctFileNames() {
+  void testSaveDistinctFileNamesForChangesMerge() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     properties.setDestinationTableName("target_table");
     properties.setSourceTableName("source_table");
     when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
-    scd1MergeDao.saveDistinctFileNames(properties);
+    scd1MergeDao.saveDistinctFileNamesForChangesMerge(properties);
 
-    verify(mockSqlSession).update("SCD1Merge.saveDistinctFileNames", properties);
+    verify(mockSqlSession).update("SCD1Merge.saveDistinctFileNamesForChangesMerge", properties);
     verify(mockSqlSession).close();
   }
 
   @Test
-  void testMergeFindDiffsWithException() {
+  void testChangesBasedMergeFindDiffsWithException() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
     doThrow(new RuntimeException("Database error")).when(mockSqlSession).update(anyString(), any());
     when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
-    assertThatThrownBy(() -> scd1MergeDao.mergeFindDiffs(properties))
+    assertThatThrownBy(() -> scd1MergeDao.changesBasedMergeFindDiffs(properties))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Database error");
 
@@ -118,12 +118,12 @@ class SCD1MergeDaoTest {
   }
 
   @Test
-  void testGetMergeUpsertsSqlWithException() {
+  void testGetChangesBasedMergeResultsSqlWithException() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     when(mockSqlSessionFactory.getSql(anyString(), any()))
         .thenThrow(new RuntimeException("SQL error"));
 
-    assertThatThrownBy(() -> scd1MergeDao.getMergeUpsertsSql(properties))
+    assertThatThrownBy(() -> scd1MergeDao.getChangesBasedMergeResultsSql(properties))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("SQL error");
   }
@@ -143,12 +143,112 @@ class SCD1MergeDaoTest {
   }
 
   @Test
-  void testSaveDistinctFileNamesWithException() {
+  void testSaveDistinctFileNamesForChangesMergeWithException() {
     SCD1MergeProperties properties = new SCD1MergeProperties();
     when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
     doThrow(new RuntimeException("Save error")).when(mockSqlSession).update(anyString(), any());
 
-    assertThatThrownBy(() -> scd1MergeDao.saveDistinctFileNames(properties))
+    assertThatThrownBy(() -> scd1MergeDao.saveDistinctFileNamesForChangesMerge(properties))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Save error");
+
+    verify(mockSqlSession).close();
+  }
+
+  @Test
+  void testSnapshotBasedMergeFindDiffs() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    properties.setDestinationTableName("target_table");
+    properties.setSourceTableName("source_table");
+    when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
+    scd1MergeDao.snapshotBasedMergeFindDiffs(properties);
+
+    verify(mockSqlSession).update("SCD1Merge.snapshotBasedMergeFindDiffs", properties);
+    verify(mockSqlSession).close();
+  }
+
+  @Test
+  void testGetSnapshotBasedMergeAppendOnlySql() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    properties.setDestinationTableName("target_table");
+    properties.setSourceTableName("source_table");
+
+    String expectedSql = "testGetSnapshotBasedMergeAppendOnlySql...";
+    when(mockSqlSessionFactory.getSql("SCD1Merge.snapshotBasedMergeAppendOnly", properties))
+        .thenReturn(expectedSql);
+    String result = scd1MergeDao.getSnapshotBasedMergeAppendOnlySql(properties);
+
+    assertThat(result).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void testGetSnapshotBasedMergeResultsSql() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    properties.setDestinationTableName("target_table");
+    properties.setSourceTableName("source_table");
+
+    String expectedSql = "testGetSnapshotBasedMergeResultsSql...";
+    when(mockSqlSessionFactory.getSql("SCD1Merge.snapshotBasedMergeResults", properties))
+        .thenReturn(expectedSql);
+    String result = scd1MergeDao.getSnapshotBasedMergeResultsSql(properties);
+
+    assertThat(result).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void testSaveDistinctFileNamesForSnapshotMerge() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    properties.setDestinationTableName("target_table");
+    properties.setSourceTableName("source_table");
+    when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
+    scd1MergeDao.saveDistinctFileNamesForSnapshotMerge(properties);
+
+    verify(mockSqlSession).update("SCD1Merge.saveDistinctFileNamesForSnapshotMerge", properties);
+    verify(mockSqlSession).close();
+  }
+
+  @Test
+  void testSnapshotBasedMergeFindDiffsWithException() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
+    doThrow(new RuntimeException("Database error")).when(mockSqlSession).update(anyString(), any());
+
+    assertThatThrownBy(() -> scd1MergeDao.snapshotBasedMergeFindDiffs(properties))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Database error");
+
+    verify(mockSqlSession).close();
+  }
+
+  @Test
+  void testGetSnapshotBasedMergeAppendOnlySqlWithException() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    when(mockSqlSessionFactory.getSql(anyString(), any()))
+        .thenThrow(new RuntimeException("SQL error"));
+
+    assertThatThrownBy(() -> scd1MergeDao.getSnapshotBasedMergeAppendOnlySql(properties))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("SQL error");
+  }
+
+  @Test
+  void testGetSnapshotBasedMergeResultsSqlWithException() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    when(mockSqlSessionFactory.getSql(anyString(), any()))
+        .thenThrow(new RuntimeException("SQL error"));
+
+    assertThatThrownBy(() -> scd1MergeDao.getSnapshotBasedMergeResultsSql(properties))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("SQL error");
+  }
+
+  @Test
+  void testSaveDistinctFileNamesForSnapshotMergeWithException() {
+    SCD1MergeProperties properties = new SCD1MergeProperties();
+    when(mockSqlSessionFactory.openSession()).thenReturn(mockSqlSession);
+    doThrow(new RuntimeException("Save error")).when(mockSqlSession).update(anyString(), any());
+
+    assertThatThrownBy(() -> scd1MergeDao.saveDistinctFileNamesForSnapshotMerge(properties))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Save error");
 

--- a/core/src/test/resources/mybatis/test_mapper.xml
+++ b/core/src/test/resources/mybatis/test_mapper.xml
@@ -28,6 +28,14 @@
         SELECT ${id2} AS id, '${name2}' AS name, ${value2} AS value, 'I' AS operation_type
     </select>
 
+    <select id="getSnapshotData" resultType="java.util.HashMap">
+        SELECT ${id1} AS id, '${name1}' AS name, ${value1} AS value
+        UNION ALL
+        SELECT ${id2} AS id, '${name2}' AS name, ${value2} AS value
+        UNION ALL
+        SELECT ${id3} AS id, '${name3}' AS name, ${value3} AS value
+    </select>
+
     <select id="getSCD2ChangeData" resultType="java.util.HashMap">
         SELECT ${id1} AS id, '${name1}' AS name, ${value1} AS value, '${opType1}' AS operation_type
         UNION ALL


### PR DESCRIPTION
Closes #1 and #4 

This commit introduces Snapshot Mode for SCD1 operations, allowing comparison of snapshots to efficiently identify and apply differences. 
The implementation includes:
- Support for value column metadata with delta tolerances and null handling
- Skip empty source option to prevent deleting records when source is empty
- Comprehensive test coverage through unit and integration tests

Additional changes:
- Fix corner case in merge cardinality checking
- Validations for SCD2 column configuration to prevent runtime errors and improve error messages.